### PR TITLE
fix: Cannot create a project after creating an account

### DIFF
--- a/dapp/src/components/NavbarSearch.tsx
+++ b/dapp/src/components/NavbarSearch.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
+import { useStore } from "@nanostores/react";
 import Button from "./utils/Button";
 
-import { loadedPublicKey } from "../service/walletService";
+import { connectedPublicKey } from "../utils/store";
 import { toast } from "../utils/utils";
 
 // Constants for URL handling
@@ -12,28 +13,15 @@ const NavbarSearch = () => {
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const [originalUrl, setOriginalUrl] = useState("");
   const [isSearchVisible, setIsSearchVisible] = useState(false);
-  const [isWalletConnected, setIsWalletConnected] = useState(false);
   const [isClient, setIsClient] = useState(false);
+  const publicKeyFromStore = useStore(connectedPublicKey);
+  const isWalletConnected = !!publicKeyFromStore;
 
   useEffect(() => {
     setIsClient(true);
 
     saveOriginalUrl();
     initializeSearchTerm();
-
-    // Check wallet connection status on client-side only
-    setIsWalletConnected(!!loadedPublicKey());
-
-    // Listen for wallet connection/disconnection events
-    const handleWalletConnection = () =>
-      setIsWalletConnected(!!loadedPublicKey());
-    window.addEventListener("walletConnected", handleWalletConnection);
-    window.addEventListener("walletDisconnected", handleWalletConnection);
-
-    return () => {
-      window.removeEventListener("walletConnected", handleWalletConnection);
-      window.removeEventListener("walletDisconnected", handleWalletConnection);
-    };
   }, []);
 
   // Save the original URL when the component mounts

--- a/dapp/src/components/page/dashboard/CreateProjectModal.tsx
+++ b/dapp/src/components/page/dashboard/CreateProjectModal.tsx
@@ -324,7 +324,6 @@ const CreateProjectModal: FC<ModalProps> = ({ onClose }) => {
     const [{ fetchTomlFromIpfs }] = await Promise.all([
       import("utils/ipfsFunctions"),
     ]);
-    const { loadedPublicKey } = await import("@service/walletService");
 
     try {
       const publicKey = loadedPublicKey();

--- a/dapp/src/constants/featuredProjectsConfigData.js
+++ b/dapp/src/constants/featuredProjectsConfigData.js
@@ -23,10 +23,12 @@ export const featuredProjectsConfigData = [
     projectType: "GENERIC",
     logoImageLink:
       "https://communityfund.stellar.org/_next/image?url=%2Fsvg%2FSCFLogo.svg&w=96&q=75",
-    description: "Stellar Community Fund Voting Platform for Public Goods Award",
+    description:
+      "Stellar Community Fund Voting Platform for Public Goods Award",
     organizationName: "Stellar Community Fund",
     officials: {
-      websiteLink: "https://stellar.gitbook.io/scf-handbook/supporting-programs/public-goods-award",
+      websiteLink:
+        "https://stellar.gitbook.io/scf-handbook/supporting-programs/public-goods-award",
     },
     socialLinks: {},
     authorHandles: ["tupui"],

--- a/dapp/src/constants/proposalTemplates.ts
+++ b/dapp/src/constants/proposalTemplates.ts
@@ -82,8 +82,7 @@ Why this change is necessary for the project's governance.
   {
     id: "pg-award-request",
     name: "Public Goods Award",
-    description:
-      "Stellar Community Fund Public Goods Award - Submission Form",
+    description: "Stellar Community Fund Public Goods Award - Submission Form",
     content: `# SCF Public Goods Award: [Project Name]
 
 #SCF Public Goods Award - Submission Form


### PR DESCRIPTION
## Summary:

1. NavbarSearch.tsx: Replaced the event-based isWalletConnected state (which relied on
  walletConnected/walletDisconnected custom events and could have timing issues) with a direct reactive subscription to
  the connectedPublicKey nanostore via useStore. This means isWalletConnected is now always in sync with the actual
  wallet connection state as soon as setConnection() is called during joining, the "Add Project" button becomes
  enabled.

  2. CreateProjectModal.tsx: Removed the redundant dynamic import("@service/walletService") inside
  handleRegisterProject. The static import of loadedPublicKey at the top of the file is sufficient  the dynamic import
  was shadowing it unnecessarily and could potentially resolve to a different module instance in some bundler
  configurations.

  Root cause: When the user creates an account (joins) via the JoinCommunityButton flow without a prior wallet
  connection, setConnection() is called and updates the nanostores, but the event-based isWalletConnected in
  NavbarSearch could be stale if there was a timing issue with the walletConnected event listener. Using useStore
  eliminates this race condition entirely.

closes #35