### PR TITLE
feat: display project_key and project_name on project page

### DIFF
--- a/dapp/src/components/page/project/ProjectInfo.astro
+++ b/dapp/src/components/page/project/ProjectInfo.astro
@@ -106,6 +106,34 @@ import Button from "components/utils/Button";
       </div>
     </div>
     <div
+      id="project-chain-info"
+      class="p-[15px_16px] lg:p-[30px_72px] bg-white flex flex-col gap-5"
+    >
+      <p class="leading-4 text-base text-secondary">On-chain Information</p>
+      <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-1">
+          <p class="text-xs text-secondary uppercase tracking-wide">Project Name</p>
+          <p id="chain-project-name" class="text-base text-primary font-mono"></p>
+        </div>
+        <div class="flex flex-col gap-1">
+          <p class="text-xs text-secondary uppercase tracking-wide">Project Key</p>
+          <div class="flex items-center gap-2">
+            <code
+              id="chain-project-key"
+              class="text-sm text-primary font-mono bg-gray-50 px-2 py-1 rounded break-all leading-relaxed"
+            ></code>
+            <button
+              id="copy-project-key"
+              class="shrink-0 p-1 rounded hover:bg-gray-100 transition-colors"
+              title="Copy project key"
+            >
+              <img src="/icons/clipboard.svg" alt="Copy" class="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
       id="project-maintainers"
       class="p-[15px_16px] lg:p-[30px_72px] bg-white flex flex-col gap-5"
     >
@@ -154,6 +182,7 @@ import Button from "components/utils/Button";
     configData as configDataStore,
     projectHasSubProjects,
     projectInfoLoaded,
+    projectState as projectStateStore,
   } from "../../../utils/store";
   import { getBadges, getMember } from "@service/ReadContractService";
 
@@ -260,6 +289,23 @@ import Button from "components/utils/Button";
 
     // Initial render
     renderModals();
+
+    const copyKeyButton = document.getElementById("copy-project-key");
+    if (copyKeyButton) {
+      copyKeyButton.addEventListener("click", () => {
+        const keyEl = document.getElementById("chain-project-key");
+        const key = keyEl?.textContent?.trim();
+        if (key) {
+          navigator.clipboard.writeText(key).then(() => {
+            const img = copyKeyButton.querySelector("img");
+            if (img) {
+              img.src = "/icons/check.svg";
+              setTimeout(() => { img.src = "/icons/clipboard.svg"; }, 1500);
+            }
+          });
+        }
+      });
+    }
 
     const updateConfigButton = document.querySelector("[data-update-config]");
     const udpateConfigModal = document.getElementById(
@@ -404,6 +450,22 @@ import Button from "components/utils/Button";
 
         const configData = loadConfigData();
         const isSoftwareProject = configData?.projectType === "SOFTWARE";
+
+        // On-chain name
+        const chainNameEl = document.getElementById("chain-project-name");
+        if (chainNameEl) {
+          chainNameEl.textContent = projectInfo.name;
+        }
+
+        // On-chain project key (hex)
+        const chainKeyEl = document.getElementById("chain-project-key");
+        const stateRaw = projectStateStore.get();
+        if (chainKeyEl && stateRaw) {
+          try {
+            const parsed = JSON.parse(stateRaw);
+            chainKeyEl.textContent = parsed.project_id || "";
+          } catch {}
+        }
 
         // Show Read More + Last Hash buttons only for SOFTWARE projects
         const readMoreWrapper = document.getElementById(

--- a/dapp/src/components/page/project/ProjectInfo.astro
+++ b/dapp/src/components/page/project/ProjectInfo.astro
@@ -112,11 +112,16 @@ import Button from "components/utils/Button";
       <p class="leading-4 text-base text-secondary">On-chain Information</p>
       <div class="flex flex-col gap-4">
         <div class="flex flex-col gap-1">
-          <p class="text-xs text-secondary uppercase tracking-wide">Project Name</p>
-          <p id="chain-project-name" class="text-base text-primary font-mono"></p>
+          <p class="text-xs text-secondary uppercase tracking-wide">
+            Project Name
+          </p>
+          <p id="chain-project-name" class="text-base text-primary font-mono">
+          </p>
         </div>
         <div class="flex flex-col gap-1">
-          <p class="text-xs text-secondary uppercase tracking-wide">Project Key</p>
+          <p class="text-xs text-secondary uppercase tracking-wide">
+            Project Key
+          </p>
           <div class="flex items-center gap-2">
             <code
               id="chain-project-key"
@@ -300,7 +305,9 @@ import Button from "components/utils/Button";
             const img = copyKeyButton.querySelector("img");
             if (img) {
               img.src = "/icons/check.svg";
-              setTimeout(() => { img.src = "/icons/clipboard.svg"; }, 1500);
+              setTimeout(() => {
+                img.src = "/icons/clipboard.svg";
+              }, 1500);
             }
           });
         }


### PR DESCRIPTION
## Display project_key and project_name on project page

### What changed and why

The project page was missing the project name and key from the Soroban contract.
This PR adds them to the page.

### What was added

A new **On-chain Information** panel now appears between the project
header and the Maintainers section. It shows two fields:

- **Project Name** — the raw name string exactly as it was registered in
  the Soroban contract (not the display name override from the TOML file)
- **Project Key** — the full 64-character hex representation of the
  keccak256 hash of the project name, which is the actual storage key
  used on-chain

The Project Key also has a copy-to-clipboard button. Click it and the
icon briefly switches to a checkmark to confirm the copy, then resets.

### Files changed

**`dapp/src/components/page/project/ProjectInfo.astro`**

- Added the `#project-chain-info` panel in the HTML template with two
  labelled fields (`#chain-project-name` and `#chain-project-key`) and a
  clipboard button using the existing `clipboard.svg` icon
- Imported the `projectState` nanostore from `utils/store` to read the
  serialized project key hex
- Wired up the copy button with a click handler that swaps the icon on
  success
- Extended `updateProjectInfo()` to populate both fields — the name comes
  from `loadProjectInfo().name` and the key is parsed from the
  `project_id` field in the `projectState` nanostore. No extra network
  request is needed; both values are already in memory by the time the
  rest of the page loads

### ScreenShot
<img width="1280" height="626" alt="Screenshot from 2026-04-22 23-44-06" src="https://github.com/user-attachments/assets/4bf9fa2e-bab2-44d6-9841-c19efef7b557" />


Closes #67