### PR TITLE
fix: update Tansu social card metadata and homepage title

### DIFF
--- a/dapp/src/layouts/Layout.astro
+++ b/dapp/src/layouts/Layout.astro
@@ -148,7 +148,7 @@ const { title, page } = Astro.props;
 
     <SEO
       title={title}
-      description="Bringing open source software development onto the Stellar blockchain. Tansu enables decentralized project governance, transparent funding, and collaborative development on Stellar."
+      description="Tansu provides cryptographic proof of code integrity and transparent governance for open-source projects. Built on the Stellar smart contract platform, it offers immutable commit tracking, community-driven proposals, and privacy-preserving voting mechanisms."
       canonical={`https://app.tansu.dev${Astro.url.pathname}`}
       openGraph={{
         basic: {
@@ -159,7 +159,7 @@ const { title, page } = Astro.props;
         },
         optional: {
           description:
-            "Bringing open source software development onto the Stellar blockchain. Tansu enables decentralized project governance, transparent funding, and collaborative development on Stellar.",
+            "Tansu provides cryptographic proof of code integrity and transparent governance for open-source projects. Built on the Stellar smart contract platform, it offers immutable commit tracking, community-driven proposals, and privacy-preserving voting mechanisms.",
           siteName: "Tansu",
         },
       }}
@@ -169,7 +169,7 @@ const { title, page } = Astro.props;
         image: "https://app.tansu.dev/social-card.png",
         title: title,
         description:
-          "Bringing open source software development onto the Stellar blockchain",
+          "Tansu provides cryptographic proof of code integrity and transparent governance for open-source projects. Built on the Stellar smart contract platform, it offers immutable commit tracking, community-driven proposals, and privacy-preserving voting mechanisms.",
       }}
       extend={{
         // extending the default link tags

--- a/dapp/src/pages/index.astro
+++ b/dapp/src/pages/index.astro
@@ -8,7 +8,7 @@ import ProjectListWithBoundary from "../components/page/dashboard/ProjectListWit
 <script is:inline>
   var global = global || window;
 </script>
-<Layout title="Tansu" page="home">
+<Layout title="Tansu - Decentralized project governance on Stellar" page="home">
   <Container>
     <ProjectListWithBoundary client:load />
   </Container>

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -78,18 +78,24 @@ const config: Config = {
   themeConfig: {
     image: "img/social-card.png",
     metadata: [
-      { name: "x:creator", content: "@PamphileRoy" },
-      { name: "x:card", content: "summary_large_image" },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:creator", content: "@PamphileRoy" },
+      { name: "twitter:title", content: "Tansu - Decentralized project governance on Stellar" },
       {
-        name: "x:image",
-        content: "https://tansu.dev/img/social-card.png",
-      },
-      { name: "x:title", content: "Tansu" },
-      {
-        name: "x:description",
+        name: "twitter:description",
         content:
-          "Bringing open source software development onto the Stellar blockchain",
+          "Tansu provides cryptographic proof of code integrity and transparent governance for open-source projects. Built on the Stellar smart contract platform, it offers immutable commit tracking, community-driven proposals, and privacy-preserving voting mechanisms.",
       },
+      { name: "twitter:image", content: "https://tansu.dev/img/social-card.png" },
+      { property: "og:title", content: "Tansu - Decentralized project governance on Stellar" },
+      {
+        property: "og:description",
+        content:
+          "Tansu provides cryptographic proof of code integrity and transparent governance for open-source projects. Built on the Stellar smart contract platform, it offers immutable commit tracking, community-driven proposals, and privacy-preserving voting mechanisms.",
+      },
+      { property: "og:image", content: "https://tansu.dev/img/social-card.png" },
+      { property: "og:type", content: "website" },
+      { property: "og:site_name", content: "Tansu" },
     ],
     navbar: {
       title: "Tansu",


### PR DESCRIPTION
close #69 

## PR Description

### Summary
Update the social preview metadata and homepage title to match the requested social card copy for Tansu.

### What changed
- docusaurus.config.ts
  - Replaced old `x:*` metadata with proper `twitter:*` and `og:*` tags
  - Set `twitter:title` / `og:title` to: `Tansu - Decentralized project governance on Stellar`
  - Set `twitter:description` / `og:description` to the requested summary text
  - Added explicit `twitter:image` and `og:image` values

- Layout.astro
  - Updated the SEO description and social card description metadata to the requested copy

- index.astro
  - Updated the homepage title to `Tansu - Decentralized project governance on Stellar`

### Why
The site was not using the requested social card text content for its Open Graph / Twitter metadata. This fix ensures the social preview titles and descriptions match the issue requirements.

### Verification
- Confirm no diagnostics/errors in:
  - docusaurus.config.ts
  - Layout.astro
  - index.astro
- Confirm local metadata in the page `<head>` includes:
  - `og:title`
  - `og:description`
  - `twitter:title`
  - `twitter:description`
- Confirm the current social card image asset remains social-card.png

### Testing
1. Run the Docusaurus site locally:
   - `cd website && npm start`
2. Run the Astro dApp locally:
   - `cd dapp && npm run dev`
3. Open the homepage in the browser and inspect the head metadata.