### PR TITLE
fix(navigation): reset stale modal atom and prevent mount race conditions

### DIFF
--- a/dapp/src/components/NavbarSearch.tsx
+++ b/dapp/src/components/NavbarSearch.tsx
@@ -86,7 +86,7 @@ const NavbarSearch = () => {
       window.location.pathname === HOME_PATH &&
       window.location.search
     ) {
-      window.history.pushState({}, "", HOME_PATH);
+      window.history.replaceState({}, "", HOME_PATH);
     }
   };
 
@@ -111,7 +111,7 @@ const NavbarSearch = () => {
         const url = new URL(window.location.href);
         url.searchParams.set("search", searchTerm);
         url.searchParams.set("member", "true");
-        window.history.pushState({}, "", url.toString());
+        window.history.replaceState({}, "", url.toString());
         window.dispatchEvent(
           new CustomEvent("search-member", { detail: searchTerm }),
         );
@@ -125,7 +125,7 @@ const NavbarSearch = () => {
         const url = new URL(window.location.href);
         url.searchParams.set("search", searchTerm);
         url.searchParams.delete("member");
-        window.history.pushState({}, "", url.toString());
+        window.history.replaceState({}, "", url.toString());
         window.dispatchEvent(
           new CustomEvent("search-projects", { detail: searchTerm }),
         );

--- a/dapp/src/components/page/dashboard/ProjectList.jsx
+++ b/dapp/src/components/page/dashboard/ProjectList.jsx
@@ -46,6 +46,7 @@ const ProjectList = () => {
   const [hasNextPage, setHasNextPage] = useState(true);
 
   const searchTimeoutRef = useRef(null);
+  const modalSyncSkipRef = useRef(true);
 
   // Modal handlers
   const handleCreateProjectModal = useCallback(() => {
@@ -58,6 +59,8 @@ const ProjectList = () => {
 
   // Initial fetch + URL search handling
   useEffect(() => {
+    projectCardModalOpen.set(false);
+
     const fetchProjects = async () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
       const data = getFeaturedProjectsConfigData();
@@ -151,6 +154,10 @@ const ProjectList = () => {
   }, [handleCreateProjectModal]);
 
   useEffect(() => {
+    if (modalSyncSkipRef.current) {
+      modalSyncSkipRef.current = false;
+      return;
+    }
     setShowProjectInfoModal(isProjectInfoModalOpen);
   }, [isProjectInfoModalOpen]);
 


### PR DESCRIPTION
### Description
Fixed inconsistent home redirection and history stack pollution.

### Changes
- **ProjectList.jsx**: Implemented a `useRef` guard to skip the initial sync of `projectCardModalOpen`. This prevents a race condition during Astro SPA transitions where stale atom states caused a visual flash of the modal.
- **ProjectList.jsx**: Forced `projectCardModalOpen` reset to `false` on mount to ensure a clean home state.
- **NavbarSearch.tsx**: Replaced `pushState` with `replaceState` to prevent search queries from cluttering the browser history stack.

### Manual Verification
- Verified that consecutive searches no longer accumulate in the browser history.
- Confirmed that clicking the logo or using the "Back" button from `/project` or `/governance` returns to a clean Home state without artifacts.
- Tested under React 18 batching to ensure zero visual flashes during remount.

Let me know if any further adjustments are needed, thanksss 

closes #68 