### PR TITLE
feat: highlight winning outcome in proposal voting results

### DIFF
--- a/dapp/src/components/page/proposal/ProposalDetail.tsx
+++ b/dapp/src/components/page/proposal/ProposalDetail.tsx
@@ -1,9 +1,13 @@
 import Button from "components/utils/Button";
 import Modal from "components/utils/Modal";
 import Markdown from "markdown-to-jsx";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import JsonView from "react18-json-view";
-import type { ProposalOutcome, OutcomeContract } from "types/proposal";
+import type {
+  ProposalOutcome,
+  OutcomeContract,
+  VoteStatus,
+} from "types/proposal";
 import { parseToLosslessJson } from "utils/passToLosslessJson";
 import * as StellarXdr from "utils/stellarXdr";
 import { capitalizeFirstLetter } from "utils/utils";
@@ -33,14 +37,37 @@ interface ProposalDetailProps {
   ipfsLink: string | null;
   description: string;
   outcome: ProposalOutcome | null;
+  voteStatus?: VoteStatus | undefined;
+  status?: string;
 }
 
 const ProposalDetail: React.FC<ProposalDetailProps> = ({
   ipfsLink,
   description,
   outcome,
+  voteStatus,
+  status,
 }) => {
   const [isReady, setIsReady] = useState(false);
+
+  const executedType = useMemo(() => {
+    if (
+      status === "approved" ||
+      status === "rejected" ||
+      status === "cancelled"
+    ) {
+      return status;
+    }
+
+    if (!voteStatus) return null;
+
+    const { approve, abstain, reject } = voteStatus;
+
+    if (approve.score > abstain.score + reject.score) return "approved";
+    if (reject.score > approve.score + abstain.score) return "rejected";
+
+    return "cancelled";
+  }, [voteStatus, status]);
 
   useEffect(() => {
     const init = async () => {
@@ -50,6 +77,8 @@ const ProposalDetail: React.FC<ProposalDetailProps> = ({
 
     init();
   }, []);
+  const canHighlightOutcome =
+    status === "approved" || status === "rejected" || status === "cancelled";
 
   return (
     <div className="flex flex-col gap-12">
@@ -97,6 +126,7 @@ const ProposalDetail: React.FC<ProposalDetailProps> = ({
                     type={type}
                     detail={detail}
                     isXdrInit={isReady}
+                    isExecuted={canHighlightOutcome && executedType === type}
                   />
                 );
               }
@@ -122,7 +152,8 @@ export const OutcomeDetail: React.FC<{
   type: string;
   detail: { description: string; xdr?: string; contract?: OutcomeContract };
   isXdrInit: boolean;
-}> = ({ type, detail, isXdrInit }) => {
+  isExecuted?: boolean;
+}> = ({ type, detail, isXdrInit, isExecuted }) => {
   const [content, setContent] = useState<any>(null);
   const [showModal, setShowModal] = useState(false);
   const [paramNames, setParamNames] = useState<string[] | null>(null);
@@ -304,13 +335,39 @@ export const OutcomeDetail: React.FC<{
 
     return null;
   };
+  const borderClass = isExecuted
+    ? type === "approved"
+      ? "border-green-500 bg-green-50"
+      : type === "rejected"
+        ? "border-red-500 bg-red-50"
+        : "border-[#FFB21E] bg-[#FFB21E] text-white"
+    : "border border-gray-200";
 
   return (
-    <div className="p-[30px] flex justify-between items-center bg-white">
+    <div
+      className={`p-[30px] flex justify-between items-center bg-white rounded-md transition-all ${borderClass}`}
+    >
       <div className="flex flex-col gap-3">
-        <p className={`text-xl font-medium text-${type}`}>
-          {capitalizeFirstLetter(type || "")}
-        </p>
+        <div className="flex items-center gap-3">
+          <p
+            className={`text-xl font-medium ${
+              type === "approved"
+                ? "text-approved"
+                : type === "rejected"
+                  ? "text-rejected"
+                  : "text-cancelled"
+            }`}
+          >
+            {capitalizeFirstLetter(type || "")}
+          </p>
+          {isExecuted && (
+            <span
+              className={`px-3 py-1 text-xs font-bold uppercase border-[#FFB21E] bg-[#FFB21E] text-white border`}
+            >
+              Most Voted Outcome
+            </span>
+          )}
+        </div>
         <p className="text-base font-semibold text-primary">
           {detail.description}
         </p>

--- a/dapp/src/components/page/proposal/ProposalPage.tsx
+++ b/dapp/src/components/page/proposal/ProposalPage.tsx
@@ -108,7 +108,7 @@ const ProposalPage: React.FC = () => {
         <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
           <Loading />
         </div>
-      ) : (
+      ) : proposal ? (
         <div className="bg-[#FFFFFFB8] px-4 sm:px-6 md:px-[72px] py-6 sm:py-8 md:py-12 flex flex-col gap-6 sm:gap-8 md:gap-12">
           <ProposalTitle
             proposal={proposal}
@@ -120,6 +120,8 @@ const ProposalPage: React.FC = () => {
             ipfsLink={proposal?.ipfsLink || null}
             description={description}
             outcome={outcome}
+            voteStatus={proposal.voteStatus}
+            status={proposal.status}
           />
           {isVotingModalOpen && (
             <VotingModal
@@ -142,6 +144,8 @@ const ProposalPage: React.FC = () => {
             />
           )}
         </div>
+      ) : (
+        <div>Proposal not found</div>
       )}
     </>
   );

--- a/dapp/src/components/page/proposal/ProposalTitle.tsx
+++ b/dapp/src/components/page/proposal/ProposalTitle.tsx
@@ -173,6 +173,7 @@ const ProposalTitle: React.FC<Props> = ({
       {showVotingResultModal && proposal?.voteStatus && (
         <VotingResultModal
           voteStatus={proposal?.voteStatus}
+          status={proposal?.status}
           projectMaintainers={maintainers}
           onClose={() => setShowVotingResultModal(false)}
         />

--- a/dapp/src/components/page/proposal/VotingResult.tsx
+++ b/dapp/src/components/page/proposal/VotingResult.tsx
@@ -5,6 +5,7 @@ import VoteTypeCheckbox from "./VoteTypeCheckbox";
 
 interface Props {
   voteStatus: VoteStatus | undefined;
+  status?: string;
   withDetail?: boolean;
   totalVotesOverride?: number;
   // When provided, the per-option numbers shown to users are counts of ballots,
@@ -14,11 +15,16 @@ interface Props {
 
 const VotingResult: FC<Props> = ({
   voteStatus,
+  status,
   withDetail,
   totalVotesOverride,
   countsOverride,
 }) => {
   const voteResult = useMemo(() => {
+    if (status === "approved") return VoteType.APPROVE;
+    if (status === "rejected") return VoteType.REJECT;
+    if (status === "cancelled") return VoteType.CANCEL;
+
     if (!voteStatus) return undefined;
 
     const { approve, abstain, reject } = voteStatus;
@@ -27,13 +33,31 @@ const VotingResult: FC<Props> = ({
     if (reject.score > approve.score + abstain.score) return VoteType.REJECT;
 
     return VoteType.CANCEL;
-  }, [voteStatus]);
+  }, [voteStatus, status]);
+
+  const isWinner = (type: VoteType) => voteResult === type;
+
+  const getCardClass = (type: VoteType) => {
+    const base =
+      "flex flex-col gap-[18px] min-w-[120px] p-3 rounded-md transition-colors";
+
+    if (!isWinner(type)) return base;
+
+    const colors =
+      type === VoteType.APPROVE
+        ? "border-approved bg-green-50"
+        : type === VoteType.REJECT
+          ? "border-rejected bg-red-50"
+          : "border-[#FFBD1E] bg-yellow-50";
+
+    return `${base} border ${colors}`;
+  };
 
   return (
     <>
       <div className="flex flex-col md:flex-row gap-4 md:gap-6">
         {voteResult && (
-          <div className="flex flex-col gap-[18px]">
+          <div className="flex flex-col gap-4.5">
             <p className="leading-4 text-base text-secondary">Final Outcome</p>
             <div className="flex items-center gap-2">
               <VoteTypeCheckbox size="sm" voteType={voteResult} />
@@ -68,8 +92,12 @@ const VotingResult: FC<Props> = ({
 
       {withDetail && (
         <div className="flex flex-col md:flex-row flex-wrap gap-4 md:gap-6 mt-4">
-          <div className="flex flex-col gap-[18px] min-w-[120px]">
-            <p className="leading-4 text-base text-approved">Approved</p>
+          {/* APPROVE */}
+          <div className={getCardClass(VoteType.APPROVE)}>
+            <div className="flex items-center justify-between">
+              <p className="leading-4 text-base text-approved">Approved</p>
+            </div>
+
             <p className="leading-6 text-lg md:text-xl text-primary">
               {countsOverride
                 ? countsOverride.approve
@@ -78,8 +106,12 @@ const VotingResult: FC<Props> = ({
             </p>
           </div>
 
-          <div className="flex flex-col gap-[18px] min-w-[120px]">
-            <p className="leading-4 text-base text-cancelled">Cancelled</p>
+          {/* CANCEL */}
+          <div className={getCardClass(VoteType.CANCEL)}>
+            <div className="flex items-center justify-between">
+              <p className="leading-4 text-base text-cancelled">Cancelled</p>
+            </div>
+
             <p className="leading-6 text-lg md:text-xl text-primary">
               {countsOverride
                 ? countsOverride.abstain
@@ -88,8 +120,12 @@ const VotingResult: FC<Props> = ({
             </p>
           </div>
 
-          <div className="flex flex-col gap-[18px] min-w-[120px]">
-            <p className="leading-4 text-base text-rejected">Rejected</p>
+          {/* REJECT */}
+          <div className={getCardClass(VoteType.REJECT)}>
+            <div className="flex items-center justify-between">
+              <p className="leading-4 text-base text-rejected">Rejected</p>
+            </div>
+
             <p className="leading-6 text-lg md:text-xl text-primary">
               {countsOverride
                 ? countsOverride.reject

--- a/dapp/src/components/page/proposal/VotingResultModal.tsx
+++ b/dapp/src/components/page/proposal/VotingResultModal.tsx
@@ -10,11 +10,13 @@ import { loadConfigData } from "@service/StateService";
 
 interface VotingResultModal extends ModalProps {
   voteStatus?: VoteStatus;
+  status?: string;
   projectMaintainers: string[];
 }
 
 const VotingResultModal: React.FC<VotingResultModal> = ({
   voteStatus,
+  status,
   projectMaintainers,
   onClose,
 }) => {
@@ -36,7 +38,11 @@ const VotingResultModal: React.FC<VotingResultModal> = ({
             </p>
           </div>
 
-          <VotingResult voteStatus={voteStatus} withDetail />
+          <VotingResult
+            voteStatus={voteStatus}
+            {...(status !== undefined && { status })}
+            withDetail
+          />
 
           <Voters
             voteStatus={voteStatus}


### PR DESCRIPTION
## Summary
- Add visual highlighting for winning outcomes in proposal voting results with colored borders and backgrounds
- Display "Most Voted Outcome" badge on executed proposals (approved/rejected/cancelled)
- Pass `voteStatus` and `status` props through proposal components to determine final outcome
- Add "Proposal not found" fallback message in ProposalPage

## Changes
- `ProposalDetail.tsx`: Add `executedType` logic and `isExecuted` prop for OutcomeDetail
- `OutcomeDetail.tsx`: Add border styling and badge for executed outcomes
- `VotingResult.tsx`: Highlight winner card with appropriate colors
- `VotingResultModal.tsx`: Pass `status` prop to VotingResult
- `ProposalPage.tsx`: Pass `voteStatus` and `status` to ProposalDetail, add not-found fallback
- `ProposalTitle.tsx`: Pass `status` to VotingResultModal

Closes #82 