### PR TITLE
fix(dapp): export decoded votes

### DIFF
--- a/dapp/astro.config.mjs
+++ b/dapp/astro.config.mjs
@@ -6,4 +6,9 @@ import netlify from "@astrojs/netlify";
 export default defineConfig({
   integrations: [react()],
   adapter: netlify(),
+  vite: {
+    optimizeDeps: {
+      include: ["ipfs-car"],
+    },
+  },
 });

--- a/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
+++ b/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
@@ -77,8 +77,7 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
 
           <div className="flex flex-col items-center justify-between gap-3 flex-wrap mt-3">
             <p className="text-xs md:text-sm text-secondary max-w-prose">
-              Exporting decoded votes removes anonymity from the file. Keep it
-              private.
+              Exporting decoded votes compromise the privacy model.
             </p>
             <Button
               type="primary"
@@ -117,9 +116,10 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
             the proposal.
           </p>
           <p className="text-xs md:text-sm text-secondary max-w-prose">
-            Final outcomes are based on weighted vote totals. A proposal can
-            still cancel if approvals do not exceed rejections plus abstentions
-            once weights are applied.
+            Final outcomes are based on weighted vote tallies. For a proposal
+            to be accepted, the tally of approve votes must be higher than
+            the sum of the tallies of reject plus cancel votes. Same goes to
+            reject a proposal.
           </p>
         </div>
       )}

--- a/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
+++ b/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
@@ -76,9 +76,6 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
           </details>
 
           <div className="flex flex-col items-center justify-between gap-3 flex-wrap mt-3">
-            <p className="text-xs md:text-sm text-secondary max-w-prose">
-              Exporting decoded votes compromise the privacy model.
-            </p>
             <Button
               type="primary"
               size="sm"

--- a/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
+++ b/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
@@ -1,12 +1,17 @@
+import { useState } from "react";
 import VotingResult from "./VotingResult";
 import type { VoteStatus } from "types/proposal";
 import AddressDisplay from "./AddressDisplay"; // import our new component
+import Button from "components/utils/Button";
+import ExportDecodedVotesModal from "./ExportDecodedVotesModal";
+import type { DecodedVote } from "utils/anonymousVoting";
 
 interface Props {
   voteStatus: VoteStatus | undefined;
-  decodedVotes: any[];
+  decodedVotes: DecodedVote[];
   proofOk?: boolean | null;
   proofErrorMessage?: string | null;
+  exportFileNameBase?: string;
 }
 
 const AnonymousTalliesDisplay: React.FC<Props> = ({
@@ -14,10 +19,12 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
   decodedVotes,
   proofOk,
   proofErrorMessage,
+  exportFileNameBase,
 }) => {
+  const [showExportModal, setShowExportModal] = useState(false);
   // Compute simple counts by looking at decoded votes (each row is one ballot)
   const counts = decodedVotes.reduce(
-    (acc: { approve: number; reject: number; abstain: number }, v: any) => {
+    (acc: { approve: number; reject: number; abstain: number }, v) => {
       if (v.vote === "approve") acc.approve += 1;
       else if (v.vote === "reject") acc.reject += 1;
       else acc.abstain += 1;
@@ -35,39 +42,53 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
         countsOverride={counts}
       />
       {decodedVotes.length > 0 && (
-        <details className="border border-zinc-300 rounded max-h-48 md:max-h-60 overflow-y-auto overflow-x-auto">
-          <summary className="p-2 cursor-pointer text-sm md:text-base">
-            View decoded votes
-          </summary>
-          <div className="w-full overflow-x-auto">
-            <table className="text-xs md:text-sm w-full min-w-[500px]">
-              <thead>
-                <tr className="bg-zinc-100 text-left">
-                  <th className="p-2">Address</th>
-                  <th>Vote</th>
-                  <th>Weight</th>
-                  <th>Max</th>
-                  <th>Seed</th>
-                </tr>
-              </thead>
-              <tbody>
-                {decodedVotes.map((v, i) => (
-                  <tr key={i} className="odd:bg-white even:bg-zinc-50">
-                    <td className="p-1">
-                      <AddressDisplay address={v.address} />
-                    </td>
-                    <td className="p-1">{v.vote}</td>
-                    <td className="p-1">{v.weight}</td>
-                    <td className="p-1">
-                      {v.isProposer ? "N/A" : v.maxWeight}
-                    </td>
-                    <td className="p-1">{v.seed}</td>
+        <div className="flex flex-col gap-3">
+          <details className="border border-zinc-300 rounded max-h-48 md:max-h-60 overflow-y-auto overflow-x-auto">
+            <summary className="p-2 cursor-pointer text-sm md:text-base">
+              View decoded votes
+            </summary>
+            <div className="w-full overflow-x-auto">
+              <table className="text-xs md:text-sm w-full min-w-[500px]">
+                <thead>
+                  <tr className="bg-zinc-100 text-left">
+                    <th className="p-2">Address</th>
+                    <th>Vote</th>
+                    <th>Weight</th>
+                    <th>Max</th>
+                    <th>Seed</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {decodedVotes.map((v, i) => (
+                    <tr key={i} className="odd:bg-white even:bg-zinc-50">
+                      <td className="p-1">
+                        <AddressDisplay address={v.address} />
+                      </td>
+                      <td className="p-1">{v.vote}</td>
+                      <td className="p-1">{v.weight}</td>
+                      <td className="p-1">{v.maxWeight}</td>
+                      <td className="p-1">{v.seed}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </details>
+
+          <div className="flex flex-col items-center justify-between gap-3 flex-wrap mt-3">
+            <p className="text-xs md:text-sm text-secondary max-w-prose">
+              Exporting decoded votes removes anonymity from the file. Keep it
+              private.
+            </p>
+            <Button
+              type="primary"
+              size="sm"
+              onClick={() => setShowExportModal(true)}
+            >
+              Export decoded votes
+            </Button>
           </div>
-        </details>
+        </div>
       )}
 
       {proofOk !== undefined && (
@@ -95,7 +116,20 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
             verification). Use it to confirm decrypted results before executing
             the proposal.
           </p>
+          <p className="text-xs md:text-sm text-secondary max-w-prose">
+            Final outcomes are based on weighted vote totals. A proposal can
+            still cancel if approvals do not exceed rejections plus abstentions
+            once weights are applied.
+          </p>
         </div>
+      )}
+
+      {showExportModal && (
+        <ExportDecodedVotesModal
+          decodedVotes={decodedVotes}
+          fileNameBase={exportFileNameBase || "decoded-votes"}
+          onClose={() => setShowExportModal(false)}
+        />
       )}
     </>
   );

--- a/dapp/src/components/page/proposal/ExecuteProposalModal.tsx
+++ b/dapp/src/components/page/proposal/ExecuteProposalModal.tsx
@@ -289,7 +289,7 @@ const ExecuteProposalModal: React.FC<ExecuteProposalModalProps> = ({
                 exportFileNameBase={`${projectName.replace(
                   /[^a-z0-9_-]+/gi,
                   "-",
-                )}-proposal-${proposalId}-decoded-votes`}
+                )}-proposal-${proposalId}-decoded-votes.csv`}
               />
             </div>
           </div>

--- a/dapp/src/components/page/proposal/ExecuteProposalModal.tsx
+++ b/dapp/src/components/page/proposal/ExecuteProposalModal.tsx
@@ -17,6 +17,7 @@ import {
   computeAnonymousVotingData,
   validateAnonymousKeyForProject,
 } from "utils/anonymousVoting";
+import type { DecodedVote } from "utils/anonymousVoting";
 import { loadedPublicKey } from "@service/walletService";
 import classNames from "classnames";
 import AnonymousTalliesDisplay from "./AnonymousTalliesDisplay";
@@ -46,7 +47,7 @@ const ExecuteProposalModal: React.FC<ExecuteProposalModalProps> = ({
   const [tallies, setTallies] = useState<bigint[] | null>(null);
   const [processingError, setProcessingError] = useState<string | null>(null);
   const [isMaintainer, setIsMaintainer] = useState(false);
-  const [decodedVotes, setDecodedVotes] = useState<any[]>([]);
+  const [decodedVotes, setDecodedVotes] = useState<DecodedVote[]>([]);
   const [proofOk, setProofOk] = useState<boolean | null>(null);
   const [proofErrorMessage, setProofErrorMessage] = useState<string | null>(
     null,
@@ -285,6 +286,10 @@ const ExecuteProposalModal: React.FC<ExecuteProposalModalProps> = ({
                 decodedVotes={decodedVotes}
                 proofOk={proofOk}
                 proofErrorMessage={proofErrorMessage}
+                exportFileNameBase={`${projectName.replace(
+                  /[^a-z0-9_-]+/gi,
+                  "-",
+                )}-proposal-${proposalId}-decoded-votes`}
               />
             </div>
           </div>

--- a/dapp/src/components/page/proposal/ExportDecodedVotesModal.tsx
+++ b/dapp/src/components/page/proposal/ExportDecodedVotesModal.tsx
@@ -40,10 +40,11 @@ const ExportDecodedVotesModal: React.FC<Props> = ({
           <p className="font-medium text-red-700">Privacy warning</p>
           <p className="mt-2 leading-6">
             Decoded votes reveal who voted for what. If this file is shared
-            online, forwarded, or leaked, voter privacy is lost.
+            online, forwarded, or leaked, the voter privacy assumption is lost.
           </p>
           <p className="mt-2 leading-6">
-            Only export this file if you are sure it will stay private.
+            Only export this file if you can assume the responsibility
+            of keeping voters' information private.
           </p>
         </div>
 

--- a/dapp/src/components/page/proposal/ExportDecodedVotesModal.tsx
+++ b/dapp/src/components/page/proposal/ExportDecodedVotesModal.tsx
@@ -50,7 +50,6 @@ const ExportDecodedVotesModal: React.FC<Props> = ({
 
         <div className="flex flex-col gap-2 text-sm text-secondary">
           <p>Rows to export: {decodedVotes.length}</p>
-          <p>Format: CSV</p>
         </div>
 
         <div className="flex flex-col sm:flex-row justify-end gap-3 sm:gap-[18px]">

--- a/dapp/src/components/page/proposal/ExportDecodedVotesModal.tsx
+++ b/dapp/src/components/page/proposal/ExportDecodedVotesModal.tsx
@@ -1,0 +1,66 @@
+import Button from "components/utils/Button";
+import Modal, { type ModalProps } from "components/utils/Modal";
+import Title from "components/utils/Title";
+import { buildDecodedVotesCsv } from "utils/anonymousVotingCsv";
+import type { DecodedVote } from "utils/anonymousVoting";
+
+interface Props extends ModalProps {
+  decodedVotes: DecodedVote[];
+  fileNameBase: string;
+}
+
+const ExportDecodedVotesModal: React.FC<Props> = ({
+  decodedVotes,
+  fileNameBase,
+  onClose,
+}) => {
+  const handleExport = () => {
+    const csv = buildDecodedVotesCsv(decodedVotes);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${fileNameBase || "decoded-votes"}.csv`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    window.setTimeout(() => URL.revokeObjectURL(url), 0);
+    onClose();
+  };
+
+  return (
+    <Modal onClose={onClose}>
+      <div className="flex flex-col gap-6 sm:gap-[30px] max-w-2xl">
+        <Title
+          title="Export decoded votes"
+          description="This exports the decrypted ballot rows as a CSV file."
+        />
+
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 sm:p-5 text-sm sm:text-base text-primary">
+          <p className="font-medium text-red-700">Privacy warning</p>
+          <p className="mt-2 leading-6">
+            Decoded votes reveal who voted for what. If this file is shared
+            online, forwarded, or leaked, voter privacy is lost.
+          </p>
+          <p className="mt-2 leading-6">
+            Only export this file if you are sure it will stay private.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2 text-sm text-secondary">
+          <p>Rows to export: {decodedVotes.length}</p>
+          <p>Format: CSV</p>
+        </div>
+
+        <div className="flex flex-col sm:flex-row justify-end gap-3 sm:gap-[18px]">
+          <Button type="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleExport}>Export CSV</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ExportDecodedVotesModal;

--- a/dapp/src/components/page/proposal/ProposalStatusSection.tsx
+++ b/dapp/src/components/page/proposal/ProposalStatusSection.tsx
@@ -21,7 +21,7 @@ const ProposalStatusSection: React.FC<Props> = ({ proposal }) => {
       status === "cancelled"
     ) {
       voteResult = status as VoteResultType;
-    } else {
+    } else if (voteStatus) {
       const { approve, abstain, reject } = voteStatus;
       if (approve.score > abstain.score + reject.score) {
         voteResult = VoteResultType.APPROVE;

--- a/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
+++ b/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
@@ -122,7 +122,7 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
             exportFileNameBase={`${projectName.replace(
               /[^a-z0-9_-]+/gi,
               "-",
-            )}-proposal-${proposalId}-decoded-votes`}
+            )}-proposal-${proposalId}-decoded-votes.csv`}
           />
 
           <div className="flex justify-center sm:justify-end">

--- a/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
+++ b/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
@@ -8,6 +8,7 @@ import {
   computeAnonymousVotingData,
   validateAnonymousKeyForProject,
 } from "utils/anonymousVoting";
+import type { DecodedVote } from "utils/anonymousVoting";
 import type { VoteStatus } from "types/proposal";
 import classNames from "classnames";
 
@@ -28,7 +29,7 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
   const [proofErrorMessage, setProofErrorMessage] = useState<string | null>(
     null,
   );
-  const [decodedVotes, setDecodedVotes] = useState<any[]>([]);
+  const [decodedVotes, setDecodedVotes] = useState<DecodedVote[]>([]);
 
   const computeTalliesAndProof = async (privKey: string) => {
     try {
@@ -118,6 +119,10 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
             decodedVotes={decodedVotes}
             proofOk={proofOk}
             proofErrorMessage={proofErrorMessage}
+            exportFileNameBase={`${projectName.replace(
+              /[^a-z0-9_-]+/gi,
+              "-",
+            )}-proposal-${proposalId}-decoded-votes`}
           />
 
           <div className="flex justify-center sm:justify-end">

--- a/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
+++ b/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
@@ -122,7 +122,7 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
             exportFileNameBase={`${projectName.replace(
               /[^a-z0-9_-]+/gi,
               "-",
-            )}-proposal-${proposalId}-decoded-votes.csv`}
+            )}-proposal-${proposalId}-decoded-votes`}
           />
 
           <div className="flex justify-center sm:justify-end">

--- a/dapp/src/utils/anonymousVotingCsv.ts
+++ b/dapp/src/utils/anonymousVotingCsv.ts
@@ -1,0 +1,22 @@
+import type { DecodedVote } from "./anonymousVoting";
+
+const CSV_HEADERS = ["Address", "Vote", "Weight", "Max Weight", "Seed"];
+
+export function escapeCsvValue(value: unknown): string {
+  const normalized = String(value ?? "");
+  if (!/[",\n]/.test(normalized)) {
+    return normalized;
+  }
+
+  return `"${normalized.replaceAll('"', '""')}"`;
+}
+
+export function buildDecodedVotesCsv(decodedVotes: DecodedVote[]): string {
+  const rows = decodedVotes.map((vote) =>
+    [vote.address, vote.vote, vote.weight, vote.maxWeight, vote.seed]
+      .map(escapeCsvValue)
+      .join(","),
+  );
+
+  return [CSV_HEADERS.map(escapeCsvValue).join(","), ...rows].join("\n");
+}

--- a/dapp/src/utils/contractErrors.test.ts
+++ b/dapp/src/utils/contractErrors.test.ts
@@ -42,6 +42,15 @@ describe("parseContractError", () => {
     expect(msg).not.toContain("anonymous voting");
   });
 
+  it("returns a transfer-specific hint for invalid proposal outcome inputs", () => {
+    const msg = parseContractError({
+      message:
+        "HostError: Error(WasmVm, InvalidAction) topics:[fn_call,x,transfer]",
+    });
+    expect(msg).toContain("transfer()");
+    expect(msg).toContain("configured contract address and arguments");
+  });
+
   it("returns raw message for unknown format", () => {
     const msg = parseContractError({ message: "Network timeout" });
     expect(msg).toBe("Network timeout");

--- a/dapp/src/utils/contractErrors.ts
+++ b/dapp/src/utils/contractErrors.ts
@@ -42,6 +42,10 @@ export function parseContractError(error: any): string {
       return `Invalid input for contract execution${where}. For anonymous voting, ensure your key file matches this proposal and try again.`;
     }
 
+    if (hasInvalidInputPattern && fnName === "transfer") {
+      return `Invalid input for contract execution${where}. Check the configured contract address and arguments for this proposal outcome.`;
+    }
+
     if (hasInvalidInputPattern) {
       return `Invalid input for contract execution${where}. Please verify proposal inputs and try again.`;
     }


### PR DESCRIPTION
- Adds an export button for decoded anonymous votes with a confirmation modal and a clear privacy warning before downloading CSV.
- Reuses the app’s existing modal pattern for the confirmation step.
- Improves the anonymous vote UI copy to clarify that final outcomes are based on weighted tallies, which can still lead to cancelled even when raw approve counts are higher.
- Tightens contract error messaging for finalize/execute failures so transfer() simulation errors point at the configured outcome contract inputs.
- Updates `dapp/astro.config.mjs` to explicitly include `ipfs-car` in `Vite optimizeDeps`. This was needed because project/proposal creation lazy-loads `ipfs-car`, and the dev server was failing to fetch the generated Vite chunk for it. Prebundling it makes the browser import stable during local development.


Current Implementation looks like this 
<img width="727" height="871" alt="Screenshot 2026-04-25 at 21 19 00" src="https://github.com/user-attachments/assets/3f23bc12-0b76-44a0-bd25-66b1f1d4aec6" />
----------------------------------
<img width="975" height="657" alt="Screenshot 2026-04-25 at 21 15 50" src="https://github.com/user-attachments/assets/459950e0-db7d-4cc7-8bd0-d3dfa2085970" />


Closes #73 