### PR TITLE
feat(ipfs): implement multi-provider pinning with retries

### DIFF
--- a/dapp/.env.example
+++ b/dapp/.env.example
@@ -13,3 +13,4 @@ PUBLIC_DELEGATION_API_URL="https://ipfs-testnet.tansu.dev"
 
 # Dual IPFS pinning — Filebase backup (optional but recommended for redundancy)
 FILEBASE_API_KEY=""
+PINATA_JWT=""

--- a/dapp/.env.example
+++ b/dapp/.env.example
@@ -10,3 +10,6 @@ PUBLIC_TANSU_OWNER_ID="GCILP4HWE2QGEO4KUMOZ6S6J3A46W47EVCGZW2YPYCPH5CQF6EACNBCN"
 
 # IPFS upload flows
 PUBLIC_DELEGATION_API_URL="https://ipfs-testnet.tansu.dev"
+
+# Dual IPFS pinning — Filebase backup (optional but recommended for redundancy)
+FILEBASE_API_KEY=""

--- a/dapp/src/service/FlowService.ts
+++ b/dapp/src/service/FlowService.ts
@@ -2,6 +2,7 @@ import { calculateDirectoryCid } from "../utils/ipfsFunctions";
 import { create } from "@storacha/client";
 import * as Delegation from "@ucanto/core/delegation";
 import type { OutcomeContract } from "../types/proposal";
+import { pinToFilebase } from "../utils/dualPin";
 
 //
 import Tansu from "../contracts/soroban_tansu";
@@ -107,7 +108,14 @@ export async function uploadWithDelegation({
   const directoryCid = await client.uploadDirectory(files);
   if (!directoryCid) throw new Error("Failed to upload to IPFS");
 
-  return directoryCid.toString();
+  const cid = directoryCid.toString();
+
+  // Dual pin: backup to Filebase in background (fire-and-forget)
+  pinToFilebase(cid).catch((err) => {
+    console.warn("[DualPin] Filebase backup pin failed:", err.message);
+  });
+
+  return cid;
 }
 
 /**

--- a/dapp/src/service/FlowService.ts
+++ b/dapp/src/service/FlowService.ts
@@ -2,7 +2,7 @@ import { calculateDirectoryCid } from "../utils/ipfsFunctions";
 import { create } from "@storacha/client";
 import * as Delegation from "@ucanto/core/delegation";
 import type { OutcomeContract } from "../types/proposal";
-import { pinToFilebase } from "../utils/dualPin";
+import { pinToBackups } from "../utils/dualPin";
 
 //
 import Tansu from "../contracts/soroban_tansu";
@@ -110,9 +110,9 @@ export async function uploadWithDelegation({
 
   const cid = directoryCid.toString();
 
-  // Dual pin: backup to Filebase in background (fire-and-forget)
-  pinToFilebase(cid).catch((err) => {
-    console.warn("[DualPin] Filebase backup pin failed:", err.message);
+  // Dual pin: backup to multiple providers in background (fire-and-forget)
+  pinToBackups(cid).catch((err) => {
+    console.warn("[MultiPin] Background backup pins failed:", err.message);
   });
 
   return cid;

--- a/dapp/src/utils/dualPin.test.ts
+++ b/dapp/src/utils/dualPin.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { pinToFilebase, pinToPinata, pinToBackups, pinConfig } from "./dualPin";
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe("dualPin utility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // Use vi.spyOn to mock pinConfig getters
+    vi.spyOn(pinConfig, "getFilebaseKey").mockReturnValue("fb-key");
+    vi.spyOn(pinConfig, "getPinataJwt").mockReturnValue("pn-jwt");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should attempt to pin to both providers in pinToBackups", async () => {
+    (fetch as any)
+      .mockResolvedValueOnce({ ok: true }) // Filebase
+      .mockResolvedValueOnce({ ok: true }); // Pinata
+
+    const results = await pinToBackups("bafy-cid");
+    
+    expect(results).toHaveLength(2);
+    expect(results[0].pinned).toBe(true);
+    expect(results[1].pinned).toBe(true);
+  });
+
+  it("should retry on failure", async () => {
+    (fetch as any)
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValueOnce({ ok: true });
+
+    const pinPromise = pinToFilebase("bafy-cid");
+    
+    // Fast-forward time for retries
+    await vi.runAllTimersAsync();
+    
+    const result = await pinPromise;
+    expect(result.pinned).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("should fail after max retries", async () => {
+    (fetch as any).mockRejectedValue(new Error("Persistent error"));
+
+    const pinPromise = pinToFilebase("bafy-cid");
+    
+    // Fast-forward time for retries
+    await vi.runAllTimersAsync();
+
+    const result = await pinPromise;
+    expect(result.pinned).toBe(false);
+    expect(result.error).toContain("Persistent error");
+    expect(fetch).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+  });
+
+  it("should return error if API keys are missing", async () => {
+    vi.spyOn(pinConfig, "getPinataJwt").mockReturnValue("");
+
+    const result = await pinToPinata("bafy-cid");
+    expect(result.pinned).toBe(false);
+    expect(result.error).toBe("JWT not configured");
+  });
+});

--- a/dapp/src/utils/dualPin.ts
+++ b/dapp/src/utils/dualPin.ts
@@ -1,14 +1,24 @@
 /**
- * Dual IPFS Pinning Utility
+ * Multi-Provider IPFS Pinning Utility
  *
- * Uploads data to both Storacha (primary) and Filebase (backup) to ensure
- * redundancy. If one provider fails, the other still serves as a backup.
+ * Ensures data availability by pinning CIDs to multiple providers:
+ * 1. Storacha (Primary - usually handled by the caller)
+ * 2. Filebase (Backup)
+ * 3. Pinata (Backup)
  *
- * Usage: wrap any upload call with `dualPin` to automatically pin to Filebase
- * after the primary Storacha upload succeeds.
+ * Includes automatic retries with exponential backoff for transient failures.
  */
 
 const FILEBASE_API_URL = "https://api.filebase.io/v1/ipfs";
+const PINATA_API_URL = "https://api.pinata.cloud/pinning/pinByHash";
+
+/**
+ * Accessor for environment variables, separated for testability.
+ */
+export const pinConfig = {
+  getFilebaseKey: () => import.meta.env.FILEBASE_API_KEY,
+  getPinataJwt: () => import.meta.env.PINATA_JWT,
+};
 
 type PinResult = {
   cid: string;
@@ -18,19 +28,32 @@ type PinResult = {
 };
 
 /**
+ * Generic retry helper with exponential backoff.
+ */
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  retries = 3,
+  delay = 1000,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (retries <= 0) throw err;
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return withRetry(fn, retries - 1, delay * 2);
+  }
+}
+
+/**
  * Pin a CID to Filebase as backup.
- *
- * Requires FILEBASE_API_KEY env var to be set.
- * If the key is missing, this is a no-op (graceful degradation).
  */
 export async function pinToFilebase(cid: string): Promise<PinResult> {
-  const apiKey = import.meta.env.FILEBASE_API_KEY;
+  const apiKey = pinConfig.getFilebaseKey();
   if (!apiKey) {
-    console.warn("[DualPin] FILEBASE_API_KEY not set, skipping Filebase pin");
     return { cid, pinned: false, provider: "filebase", error: "API key not configured" };
   }
 
-  try {
+  const pinAction = async () => {
     const res = await fetch(`${FILEBASE_API_URL}/pins`, {
       method: "POST",
       headers: {
@@ -44,66 +67,99 @@ export async function pinToFilebase(cid: string): Promise<PinResult> {
       signal: AbortSignal.timeout(15000),
     });
 
-    if (res.ok) {
-      console.info(`[DualPin] Filebase pin succeeded for CID: ${cid}`);
-      return { cid, pinned: true, provider: "filebase" };
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`HTTP ${res.status}: ${text}`);
     }
+    return true;
+  };
 
-    const text = await res.text();
-    console.warn(`[DualPin] Filebase pin failed: ${res.status} ${text}`);
-    return { cid, pinned: false, provider: "filebase", error: `HTTP ${res.status}` };
+  try {
+    await withRetry(pinAction);
+    console.info(`[MultiPin] Filebase pin succeeded for CID: ${cid}`);
+    return { cid, pinned: true, provider: "filebase" };
   } catch (err: any) {
-    console.warn(`[DualPin] Filebase pin error: ${err.message}`);
+    console.warn(`[MultiPin] Filebase pin failed after retries: ${err.message}`);
     return { cid, pinned: false, provider: "filebase", error: err.message };
   }
 }
 
 /**
- * Check if a CID is pinned on Filebase.
+ * Pin a CID to Pinata as backup.
  */
-export async function checkFilebasePinStatus(cid: string): Promise<boolean> {
-  const apiKey = import.meta.env.FILEBASE_API_KEY;
-  if (!apiKey) return false;
+export async function pinToPinata(cid: string): Promise<PinResult> {
+  const jwt = pinConfig.getPinataJwt();
+  if (!jwt) {
+    return { cid, pinned: false, provider: "pinata", error: "JWT not configured" };
+  }
+
+  const pinAction = async () => {
+    const res = await fetch(PINATA_API_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        hashToPin: cid,
+        pinataMetadata: {
+          name: `tansu-backup-${cid.slice(0, 12)}`,
+        },
+      }),
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`HTTP ${res.status}: ${text}`);
+    }
+    return true;
+  };
 
   try {
-    const res = await fetch(`${FILEBASE_API_URL}/pins/${cid}`, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      signal: AbortSignal.timeout(8000),
-    });
-    return res.ok;
-  } catch {
-    return false;
+    await withRetry(pinAction);
+    console.info(`[MultiPin] Pinata pin succeeded for CID: ${cid}`);
+    return { cid, pinned: true, provider: "pinata" };
+  } catch (err: any) {
+    console.warn(`[MultiPin] Pinata pin failed after retries: ${err.message}`);
+    return { cid, pinned: false, provider: "pinata", error: err.message };
   }
 }
 
 /**
+ * Trigger concurrent pins to all backup providers.
+ */
+export async function pinToBackups(cid: string): Promise<PinResult[]> {
+  return await Promise.all([
+    pinToFilebase(cid),
+    pinToPinata(cid),
+  ]);
+}
+
+/**
  * Dual-pin wrapper: executes a primary upload function, then pins the
- * resulting CID to Filebase in the background.
- *
- * @param primaryUpload - The primary upload function (e.g., Storacha)
- * @returns The CID from the primary upload (unchanged)
+ * resulting CID to all backups in the background.
  */
 export async function dualPin(
   primaryUpload: () => Promise<string>,
 ): Promise<string> {
   const cid = await primaryUpload();
 
-  // Fire-and-forget Filebase pin (don't block the user flow)
-  pinToFilebase(cid).catch((err) => {
-    console.warn("[DualPin] Background Filebase pin failed:", err.message);
+  // Fire-and-forget backup pins
+  pinToBackups(cid).catch((err) => {
+    console.warn("[MultiPin] Background backup pins failed:", err.message);
   });
 
   return cid;
 }
 
 /**
- * Dual-pin with verification: waits for both uploads to complete.
- * Use this when you need guaranteed dual-pinning before proceeding.
+ * Dual-pin with verification: waits for all uploads and backups to complete.
  */
 export async function dualPinVerified(
   primaryUpload: () => Promise<string>,
-): Promise<{ cid: string; filebasePinned: boolean }> {
+): Promise<{ cid: string; backups: PinResult[] }> {
   const cid = await primaryUpload();
-  const filebaseResult = await pinToFilebase(cid);
-  return { cid, filebasePinned: filebaseResult.pinned };
+  const backups = await pinToBackups(cid);
+  return { cid, backups };
 }

--- a/dapp/src/utils/dualPin.ts
+++ b/dapp/src/utils/dualPin.ts
@@ -1,0 +1,109 @@
+/**
+ * Dual IPFS Pinning Utility
+ *
+ * Uploads data to both Storacha (primary) and Filebase (backup) to ensure
+ * redundancy. If one provider fails, the other still serves as a backup.
+ *
+ * Usage: wrap any upload call with `dualPin` to automatically pin to Filebase
+ * after the primary Storacha upload succeeds.
+ */
+
+const FILEBASE_API_URL = "https://api.filebase.io/v1/ipfs";
+
+type PinResult = {
+  cid: string;
+  pinned: boolean;
+  provider: string;
+  error?: string;
+};
+
+/**
+ * Pin a CID to Filebase as backup.
+ *
+ * Requires FILEBASE_API_KEY env var to be set.
+ * If the key is missing, this is a no-op (graceful degradation).
+ */
+export async function pinToFilebase(cid: string): Promise<PinResult> {
+  const apiKey = import.meta.env.FILEBASE_API_KEY;
+  if (!apiKey) {
+    console.warn("[DualPin] FILEBASE_API_KEY not set, skipping Filebase pin");
+    return { cid, pinned: false, provider: "filebase", error: "API key not configured" };
+  }
+
+  try {
+    const res = await fetch(`${FILEBASE_API_URL}/pins`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        cid,
+        name: `tansu-backup-${cid.slice(0, 12)}`,
+      }),
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (res.ok) {
+      console.info(`[DualPin] Filebase pin succeeded for CID: ${cid}`);
+      return { cid, pinned: true, provider: "filebase" };
+    }
+
+    const text = await res.text();
+    console.warn(`[DualPin] Filebase pin failed: ${res.status} ${text}`);
+    return { cid, pinned: false, provider: "filebase", error: `HTTP ${res.status}` };
+  } catch (err: any) {
+    console.warn(`[DualPin] Filebase pin error: ${err.message}`);
+    return { cid, pinned: false, provider: "filebase", error: err.message };
+  }
+}
+
+/**
+ * Check if a CID is pinned on Filebase.
+ */
+export async function checkFilebasePinStatus(cid: string): Promise<boolean> {
+  const apiKey = import.meta.env.FILEBASE_API_KEY;
+  if (!apiKey) return false;
+
+  try {
+    const res = await fetch(`${FILEBASE_API_URL}/pins/${cid}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(8000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Dual-pin wrapper: executes a primary upload function, then pins the
+ * resulting CID to Filebase in the background.
+ *
+ * @param primaryUpload - The primary upload function (e.g., Storacha)
+ * @returns The CID from the primary upload (unchanged)
+ */
+export async function dualPin(
+  primaryUpload: () => Promise<string>,
+): Promise<string> {
+  const cid = await primaryUpload();
+
+  // Fire-and-forget Filebase pin (don't block the user flow)
+  pinToFilebase(cid).catch((err) => {
+    console.warn("[DualPin] Background Filebase pin failed:", err.message);
+  });
+
+  return cid;
+}
+
+/**
+ * Dual-pin with verification: waits for both uploads to complete.
+ * Use this when you need guaranteed dual-pinning before proceeding.
+ */
+export async function dualPinVerified(
+  primaryUpload: () => Promise<string>,
+): Promise<{ cid: string; filebasePinned: boolean }> {
+  const cid = await primaryUpload();
+  const filebaseResult = await pinToFilebase(cid);
+  return { cid, filebasePinned: filebaseResult.pinned };
+}


### PR DESCRIPTION
This PR enhances the IPFS pinning logic to ensure maximum content availability.

Key changes:
- Added support for Pinata as a third pinning provider alongside Storacha and Filebase.
- Implemented  logic to parallelize pinning across multiple services.
- Added a robust  helper with exponential backoff for transient pinning failures.
- Updated all DApp upload flows to utilize the new redundant pinning system.
- Added comprehensive unit tests in  (4/4 passed).

Closes #39