### PR TITLE
fix: open proposal links in a new tab

### DIFF
--- a/dapp/src/components/page/proposal/ProposalDetail.tsx
+++ b/dapp/src/components/page/proposal/ProposalDetail.tsx
@@ -99,7 +99,20 @@ const ProposalDetail: React.FC<ProposalDetailProps> = ({
         </div>
         <div className="markdown-body w-full px-4 sm:px-6 md:px-8 py-6">
           {description ? (
-            <Markdown>{description}</Markdown>
+            <Markdown
+              options={{
+                overrides: {
+                  a: {
+                    props: {
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                    },
+                  },
+                },
+              }}
+            >
+              {description}
+            </Markdown>
           ) : (
             <p className="text-gray-500 italic">
               No description available or IPFS content could not be loaded.


### PR DESCRIPTION
## Description

When a proposal creator includes links in the proposal description, those links were opening in the same browser tab — causing users to lose their current place in the proposal page. This fix ensures all links inside proposal content open in a new tab.

## Root Cause

The `<Markdown>` component in `ProposalDetail.tsx` was rendering proposal content without any custom link behavior. By default, `markdown-to-jsx` renders links as standard `<a>` tags with no `target` attribute, so the browser navigates away from the current page.

## Changes

- **`dapp/src/components/page/proposal/ProposalDetail.tsx`**: Added an `options.overrides` configuration to the `<Markdown>` component that injects `target="_blank"` and `rel="noopener noreferrer"` into every rendered `<a>` element.

This approach is consistent with how other markdown-rendering components in the codebase (e.g., `MemberProfileModal.tsx`, `TermsAcceptanceModal.tsx`) handle link overrides.

## Closes

Closes #92