### PR TITLE
fix: removed default approve vote selection

### DIFF
--- a/dapp/src/components/page/proposal/VotingModal.tsx
+++ b/dapp/src/components/page/proposal/VotingModal.tsx
@@ -25,9 +25,7 @@ const VotingModal: React.FC<VotersModalProps> = ({
   setIsVoted,
   onClose,
 }) => {
-  const [selectedOption, setSelectedOption] = useState<VoteType | null>(
-    VoteType.APPROVE,
-  );
+  const [selectedOption, setSelectedOption] = useState<VoteType | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [step, setStep] = useState(1);
   const [voteError, setVoteError] = useState<string | null>(null);


### PR DESCRIPTION
Closes #105

---

This fixes the issue where "Approve" is selected by default when opening the voting modal.

The initial state was set to VoteType.APPROVE, which caused the option to be pre-selected. I changed it to null so no option is selected when the modal opens.

Now the user has to actively choose a vote option, which keeps the behavior neutral and matches the expected flow.