### PR TITLE
Fix/loading keyfile

### DIFF
--- a/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
+++ b/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
@@ -30,7 +30,9 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
     null,
   );
   const [decodedVotes, setDecodedVotes] = useState<DecodedVote[]>([]);
+  const [isProcessing, setIsProcessing] = useState(false);
 
+  const [isProcessing, setIsProcessing] = useState(false);
   const computeTalliesAndProof = async (privKey: string) => {
     try {
       const data = await computeAnonymousVotingData(
@@ -52,6 +54,7 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
   };
 
   const handleKeyUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIsProcessing(true);
     try {
       const fileList = e.target.files;
       if (!fileList || fileList.length === 0) return;
@@ -67,6 +70,8 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
       if (count > 0) setStep(2);
     } catch (err: any) {
       setProcessingError(err.message);
+    } finally {
+      setIsProcessing(false);
     }
   };
 
@@ -88,15 +93,21 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
               "p-3 sm:p-4 text-sm sm:text-base break-words",
             )}
           >
-            <label className="cursor-pointer text-primary underline block text-center sm:text-left">
-              Choose key file
-              <input
-                type="file"
-                accept="application/json"
-                className="hidden"
-                onChange={handleKeyUpload}
-              />
-            </label>
+            {isProcessing ? (
+              <div className="text-primary text-center sm:text-left">
+                Processing key file...
+              </div>
+            ) : (
+              <label className="cursor-pointer text-primary underline block text-center sm:text-left">
+                Choose key file
+                <input
+                  type="file"
+                  accept="application/json"
+                  className="hidden"
+                  onChange={handleKeyUpload}
+                />
+              </label>
+            )}
           </div>
 
           {processingError && (

--- a/dapp/src/components/page/proposal/VotingModal.tsx
+++ b/dapp/src/components/page/proposal/VotingModal.tsx
@@ -25,9 +25,7 @@ const VotingModal: React.FC<VotersModalProps> = ({
   setIsVoted,
   onClose,
 }) => {
-  const [selectedOption, setSelectedOption] = useState<VoteType | null>(
-    VoteType.APPROVE,
-  );
+  const [selectedOption, setSelectedOption] = useState<VoteType | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [step, setStep] = useState(1);
   const [voteError, setVoteError] = useState<string | null>(null);


### PR DESCRIPTION
This adds a loading state when processing the key file in the voting modal.

Large ballots take a few seconds to decode, and before this change the UI looked stuck during that time. I added a simple loading message so the user knows the process is ongoing.

Once processing is complete, the flow continues as before.


closes #106 