### PR TITLE
Fix/highlight exceeded weight

### DIFF
--- a/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
+++ b/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
@@ -59,17 +59,28 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
                   </tr>
                 </thead>
                 <tbody>
-                  {decodedVotes.map((v, i) => (
-                    <tr key={i} className="odd:bg-white even:bg-zinc-50">
-                      <td className="p-1">
-                        <AddressDisplay address={v.address} />
-                      </td>
-                      <td className="p-1">{v.vote}</td>
-                      <td className="p-1">{v.weight}</td>
-                      <td className="p-1">{v.maxWeight}</td>
-                      <td className="p-1">{v.seed}</td>
-                    </tr>
-                  ))}
+                  {decodedVotes.map((v, i) => {
+                    const maxWeightNum = Number(v.maxWeight);
+                    const isExceeded = !isNaN(maxWeightNum) && v.weight > maxWeightNum;
+                    
+                    return (
+                      <tr
+                        key={i}
+                        className={classNames(
+                          "odd:bg-white even:bg-zinc-50",
+                          isExceeded && "!bg-yellow-100"
+                        )}
+                      >
+                        <td className="p-1">
+                          <AddressDisplay address={v.address} />
+                        </td>
+                        <td className="p-1">{v.vote}</td>
+                        <td className="p-1">{v.weight}</td>
+                        <td className="p-1">{v.maxWeight}</td>
+                        <td className="p-1">{v.seed}</td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
+++ b/dapp/src/components/page/proposal/VerifyAnonymousVotesModal.tsx
@@ -30,7 +30,9 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
     null,
   );
   const [decodedVotes, setDecodedVotes] = useState<DecodedVote[]>([]);
+  const [isProcessing, setIsProcessing] = useState(false);
 
+  const [isProcessing, setIsProcessing] = useState(false);
   const computeTalliesAndProof = async (privKey: string) => {
     try {
       const data = await computeAnonymousVotingData(
@@ -52,6 +54,7 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
   };
 
   const handleKeyUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIsProcessing(true);
     try {
       const fileList = e.target.files;
       if (!fileList || fileList.length === 0) return;
@@ -67,6 +70,8 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
       if (count > 0) setStep(2);
     } catch (err: any) {
       setProcessingError(err.message);
+    } finally {
+      setIsProcessing(false);
     }
   };
 
@@ -88,15 +93,21 @@ const VerifyAnonymousVotesModal: React.FC<Props> = ({
               "p-3 sm:p-4 text-sm sm:text-base break-words",
             )}
           >
-            <label className="cursor-pointer text-primary underline block text-center sm:text-left">
-              Choose key file
-              <input
-                type="file"
-                accept="application/json"
-                className="hidden"
-                onChange={handleKeyUpload}
-              />
-            </label>
+            {isProcessing ? (
+              <div className="text-primary text-center sm:text-left">
+                Processing key file...
+              </div>
+            ) : (
+              <label className="cursor-pointer text-primary underline block text-center sm:text-left">
+                Choose key file
+                <input
+                  type="file"
+                  accept="application/json"
+                  className="hidden"
+                  onChange={handleKeyUpload}
+                />
+              </label>
+            )}
           </div>
 
           {processingError && (

--- a/dapp/src/components/page/proposal/VotingModal.tsx
+++ b/dapp/src/components/page/proposal/VotingModal.tsx
@@ -25,9 +25,7 @@ const VotingModal: React.FC<VotersModalProps> = ({
   setIsVoted,
   onClose,
 }) => {
-  const [selectedOption, setSelectedOption] = useState<VoteType | null>(
-    VoteType.APPROVE,
-  );
+  const [selectedOption, setSelectedOption] = useState<VoteType | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [step, setStep] = useState(1);
   const [voteError, setVoteError] = useState<string | null>(null);


### PR DESCRIPTION
Adds a visual highlight for rows where the vote weight exceeds the max allowed weight.

This helps make those edge cases easier to spot while reviewing decoded votes. The check handles both numeric and string values and ignores cases like "N/A".

The change is purely visual and does not affect any validation or flow.

closes #108