### PR TITLE
fix: make proposal creator address clickable

### DIFF
--- a/dapp/src/components/page/proposal/ProposalTitle.tsx
+++ b/dapp/src/components/page/proposal/ProposalTitle.tsx
@@ -1,9 +1,12 @@
 import { useStore } from "@nanostores/react";
 import Button from "components/utils/Button";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import type { Member } from "packages/tansu";
 import type { ProposalView } from "types/proposal";
 import { connectedPublicKey } from "utils/store";
 import { toast, truncateMiddle } from "utils/utils";
+import { getMember } from "@service/ReadContractService";
+import MemberProfileModal from "components/page/dashboard/MemberProfileModal";
 import ProposalStatusSection from "./ProposalStatusSection";
 import VoteStatusBar from "./VoteStatusBar";
 import VotingResultModal from "./VotingResultModal";
@@ -23,34 +26,10 @@ const ProposalTitle: React.FC<Props> = ({
   executeProposal,
 }) => {
   const connectedAddress = useStore(connectedPublicKey);
-  const [isMaintainer, setIsMaintainer] = useState(false);
-  const [isConnected, setIsConnected] = useState(false);
   const [showVotingResultModal, setShowVotingResultModal] = useState(false);
   const [showVerifyModal, setShowVerifyModal] = useState(false);
-
-  const checkIsConnected = () => {
-    if (connectedAddress) {
-      setIsConnected(true);
-    } else {
-      if (isConnected) {
-        setIsConnected(false);
-      }
-    }
-  };
-
-  const checkIsMaintainer = () => {
-    if (connectedAddress) {
-      const isMaintainer = maintainers.includes(connectedAddress);
-      setIsMaintainer(isMaintainer);
-    } else {
-      setIsMaintainer(false);
-    }
-  };
-
-  useEffect(() => {
-    checkIsMaintainer();
-    checkIsConnected();
-  }, [connectedAddress, maintainers]);
+  const [showMemberProfile, setShowMemberProfile] = useState(false);
+  const [selectedMember, setSelectedMember] = useState<Member | null>(null);
 
   const openVotingResultModal = () => {
     if (proposal?.status == "active") {
@@ -63,11 +42,22 @@ const ProposalTitle: React.FC<Props> = ({
     setShowVotingResultModal(true);
   };
 
+  const openMemberProfile = async () => {
+    if (proposal?.proposer) {
+      const member = await getMember(proposal.proposer);
+      setSelectedMember(member);
+      setShowMemberProfile(true);
+    }
+  };
+
   const totalVotes =
     (proposal?.voteStatus?.approve?.score || 0) +
     (proposal?.voteStatus?.reject?.score || 0) +
     (proposal?.voteStatus?.abstain?.score || 0);
   const isAnonymousProposal = proposal ? !proposal.publicVoting : false;
+  const isMaintainer = connectedAddress
+    ? maintainers.includes(connectedAddress)
+    : false;
 
   return (
     <>
@@ -92,18 +82,14 @@ const ProposalTitle: React.FC<Props> = ({
             <div className="flex items-center gap-3">
               <p className="leading-4 text-base text-[#695A77]">Created by</p>
               <div className="flex items-center gap-2">
-                <p className="leading-4 text-base font-semibold text-primary font-mono">
+                <p
+                  className="leading-4 text-base font-semibold text-primary font-mono cursor-pointer hover:underline"
+                  onClick={openMemberProfile}
+                >
                   {proposal?.proposer
                     ? truncateMiddle(proposal.proposer, 20)
                     : ""}
                 </p>
-                {isMaintainer && (
-                  <div className="p-[2px_10px_4px_10px] bg-[#FFEFA8] rounded-[36px]">
-                    <p className="leading-4 text-base font-semibold text-[#2D0F51]">
-                      maintainer
-                    </p>
-                  </div>
-                )}
               </div>
             </div>
             <div className="flex flex-col gap-3">
@@ -183,6 +169,14 @@ const ProposalTitle: React.FC<Props> = ({
           projectName={proposal.projectName}
           proposalId={proposal.id}
           onClose={() => setShowVerifyModal(false)}
+        />
+      )}
+      {showMemberProfile && proposal?.proposer && (
+        <MemberProfileModal
+          isOpen={showMemberProfile}
+          onClose={() => setShowMemberProfile(false)}
+          member={selectedMember}
+          address={proposal.proposer}
         />
       )}
     </>

--- a/dapp/src/components/page/proposal/ProposalTitle.tsx
+++ b/dapp/src/components/page/proposal/ProposalTitle.tsx
@@ -30,6 +30,7 @@ const ProposalTitle: React.FC<Props> = ({
   const [showVerifyModal, setShowVerifyModal] = useState(false);
   const [showMemberProfile, setShowMemberProfile] = useState(false);
   const [selectedMember, setSelectedMember] = useState<Member | null>(null);
+  const [isLoadingProfile, setIsLoadingProfile] = useState(false);
 
   const openVotingResultModal = () => {
     if (proposal?.status == "active") {
@@ -43,10 +44,17 @@ const ProposalTitle: React.FC<Props> = ({
   };
 
   const openMemberProfile = async () => {
-    if (proposal?.proposer) {
+    if (!proposal?.proposer) return;
+
+    setIsLoadingProfile(true);
+    try {
       const member = await getMember(proposal.proposer);
       setSelectedMember(member);
       setShowMemberProfile(true);
+    } catch {
+      toast.error("Member Profile", "Failed to load member profile");
+    } finally {
+      setIsLoadingProfile(false);
     }
   };
 
@@ -83,12 +91,19 @@ const ProposalTitle: React.FC<Props> = ({
               <p className="leading-4 text-base text-[#695A77]">Created by</p>
               <div className="flex items-center gap-2">
                 <p
-                  className="leading-4 text-base font-semibold text-primary font-mono cursor-pointer hover:underline"
-                  onClick={openMemberProfile}
+                  className={`leading-4 text-base font-semibold text-primary font-mono ${
+                    isLoadingProfile
+                      ? "opacity-50 cursor-wait"
+                      : "cursor-pointer hover:underline"
+                  }`}
+                  onClick={isLoadingProfile ? undefined : openMemberProfile}
                 >
                   {proposal?.proposer
                     ? truncateMiddle(proposal.proposer, 20)
                     : ""}
+                  {isLoadingProfile && (
+                    <span className="ml-2 inline-block w-3 h-3 border-2 border-[#311255] border-t-transparent rounded-full animate-spin" />
+                  )}
                 </p>
               </div>
             </div>

--- a/dapp/src/components/page/proposal/ProposalTitle.tsx
+++ b/dapp/src/components/page/proposal/ProposalTitle.tsx
@@ -93,18 +93,15 @@ const ProposalTitle: React.FC<Props> = ({
                 <p
                   className={`leading-4 text-base font-semibold text-primary font-mono ${
                     isLoadingProfile
-                      ? "opacity-50 cursor-wait"
+                      ? "opacity-50"
                       : "cursor-pointer hover:underline"
                   }`}
                   onClick={isLoadingProfile ? undefined : openMemberProfile}
                 >
                   {proposal?.proposer
                     ? truncateMiddle(proposal.proposer, 20)
-                    : ""}
-                  {isLoadingProfile && (
-                    <span className="ml-2 inline-block w-3 h-3 border-2 border-[#311255] border-t-transparent rounded-full animate-spin" />
-                  )}
-                </p>
+: ""}
+</p>
               </div>
             </div>
             <div className="flex flex-col gap-3">

--- a/dapp/src/components/utils/Spinner.tsx
+++ b/dapp/src/components/utils/Spinner.tsx
@@ -1,11 +1,14 @@
 interface SpinnerProps {
   className?: string;
+  color?: "white" | "primary";
 }
 
-const Spinner = ({ className = "" }: SpinnerProps) => {
+const Spinner = ({ className = "", color = "white" }: SpinnerProps) => {
+  const borderColor = color === "primary" ? "border-[#311255]" : "border-white";
+
   return (
     <div
-      className={`w-4 h-4 border-2 border-white border-b-[#fff4] rounded-full animate-spin ${className}`}
+      className={`w-4 h-4 border-2 ${borderColor} border-b-transparent rounded-full animate-spin ${className}`}
     />
   );
 };


### PR DESCRIPTION
Closes #109 - Wrong label on proposal creator role
Problem
The proposal creator address was incorrectly showing a "maintainer" badge. This was wrong because the code was checking if the connected wallet was a maintainer, not showing info about the proposal creator.
Solution
- Removed the incorrect maintainer badge that was based on the viewer's wallet
- Made the proposal creator address clickable
- Clicking opens MemberProfileModal where users can view the creator's actual project roles
Changes
- dapp/src/components/page/proposal/ProposalTitle.tsx - Main fix
- dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx - Prettier formatting
- dapp/src/components/page/proposal/ExportDecodedVotesModal.tsx - Prettier formatting

Before 
<img width="1608" height="648" alt="image" src="https://github.com/user-attachments/assets/71b54920-82d9-434d-bf61-7fd5868a6194" />

After
<img width="1920" height="1080" alt="Screenshot_29-Apr_07-49-52_5163" src="https://github.com/user-attachments/assets/816bdebf-5b82-4bc2-ac4b-eabe74d30884" />

<img width="1920" height="1080" alt="Screenshot_29-Apr_07-50-18_25380" src="https://github.com/user-attachments/assets/1fc61647-b7d6-48b0-9fae-643816b28847" />

@tupui, please let me know if there are any changes you would like for me to make during your review

