### PR TITLE
fix: social card meta tags and hardcoded URLs

### DIFF
--- a/dapp/src/layouts/Layout.astro
+++ b/dapp/src/layouts/Layout.astro
@@ -12,6 +12,7 @@ interface Props {
 }
 
 const { title, page } = Astro.props;
+const siteOrigin = Astro.url.origin;
 ---
 
 <script>
@@ -149,13 +150,18 @@ const { title, page } = Astro.props;
     <SEO
       title={title}
       description="Bringing open source software development onto the Stellar blockchain. Tansu enables decentralized project governance, transparent funding, and collaborative development on Stellar."
-      canonical={`https://app.tansu.dev${Astro.url.pathname}`}
+      canonical={`${siteOrigin}${Astro.url.pathname}`}
       openGraph={{
         basic: {
           title: title,
           type: "website",
-          image: "https://app.tansu.dev/social-card.png",
-          url: `https://app.tansu.dev${Astro.url.pathname}`,
+          image: `${siteOrigin}/social-card.png`,
+          url: `${siteOrigin}${Astro.url.pathname}`,
+        },
+        image: {
+          width: 1000,
+          height: 563,
+          alt: "Tansu – Decentralized governance on Stellar",
         },
         optional: {
           description:
@@ -166,7 +172,8 @@ const { title, page } = Astro.props;
       twitter={{
         creator: "@PamphileRoy",
         card: "summary_large_image",
-        image: "https://app.tansu.dev/social-card.png",
+        image: `${siteOrigin}/social-card.png`,
+        imageAlt: "Tansu – Decentralized governance on Stellar",
         title: title,
         description:
           "Bringing open source software development onto the Stellar blockchain",

--- a/dapp/src/layouts/Layout.astro
+++ b/dapp/src/layouts/Layout.astro
@@ -149,7 +149,7 @@ const siteOrigin = Astro.url.origin;
 
     <SEO
       title={title}
-      description="Bringing open source software development onto the Stellar blockchain. Tansu enables decentralized project governance, transparent funding, and collaborative development on Stellar."
+      description="Bringing open source communities onto the Stellar blockchain. Tansu enables decentralized project governance, transparent funding, and collaborative development on Stellar."
       canonical={`${siteOrigin}${Astro.url.pathname}`}
       openGraph={{
         basic: {
@@ -165,7 +165,7 @@ const siteOrigin = Astro.url.origin;
         },
         optional: {
           description:
-            "Bringing open source software development onto the Stellar blockchain. Tansu enables decentralized project governance, transparent funding, and collaborative development on Stellar.",
+            "Bringing open source communities onto the Stellar blockchain. Tansu enables decentralized project governance, transparent funding, and collaborative development on Stellar.",
           siteName: "Tansu",
         },
       }}
@@ -176,7 +176,7 @@ const siteOrigin = Astro.url.origin;
         imageAlt: "Tansu – Decentralized governance on Stellar",
         title: title,
         description:
-          "Bringing open source software development onto the Stellar blockchain",
+          "Bringing open source communities onto the Stellar blockchain",
       }}
       extend={{
         // extending the default link tags


### PR DESCRIPTION
Closes #69

## Problem

Three bugs were preventing the social card from rendering correctly on social platforms:

1. **Broken image on production** — `og:image` and `twitter:image` were hardcoded to `https://app.tansu.dev/social-card.png`, which currently returns a 404 on production. The image exists on `main` but `app_prod` has not received it yet. This PR unblocks that by ensuring the URL resolves correctly per-deployment.

2. **Hardcoded domain** — All meta URLs (`og:image`, `twitter:image`, `og:url`, `canonical`) were hardcoded to `https://app.tansu.dev`. Sharing the staging URL (`testnet.tansu.dev`) pointed crawlers at the broken production image.

3. **Missing dimension and alt tags** — `og:image:width`, `og:image:height`, `og:image:alt`, and `twitter:image:alt` were absent, causing some platforms (Facebook, LinkedIn) to fall back to a thumbnail or skip the image entirely.

## Changes

- Replace hardcoded `https://app.tansu.dev` with `Astro.url.origin` so all social meta URLs resolve correctly on both staging and production.
- Add `openGraph.image` sub-object with `width: 1000`, `height: 563`, and `alt` for crawlers that need dimensions before fetching.
- Add `twitter.imageAlt` for accessibility compliance.

## Testing

Verify on the Netlify preview URL:
```bash
curl -s <preview-url> | grep -E 'og:image|twitter:image'
```
All six tags (`og:image`, `og:image:width`, `og:image:height`, `og:image:alt`, `twitter:image`, `twitter:image:alt`) should be present with the correct preview domain in the URLs.