### PR TITLE
fix: avoid preselecting vote option

### DIFF
--- a/dapp/src/components/page/proposal/VoteTypeCheckbox.tsx
+++ b/dapp/src/components/page/proposal/VoteTypeCheckbox.tsx
@@ -23,11 +23,7 @@ const VoteTypeCheckbox: FC<Props> = ({
   const width = `${sizeMap[size]}px`,
     height = `${sizeMap[size]}px`;
   const renderIcon = () => {
-    if (currentVoteType === null) {
-      return <img src="/icons/check-blank.svg" style={{ width, height }} />;
-    }
-
-    if (voteType == currentVoteType || currentVoteType === undefined) {
+    if (voteType == currentVoteType) {
       if (voteType == VoteType.APPROVE) {
         return <img src="/icons/check-approve.svg" style={{ width, height }} />;
       }

--- a/dapp/src/components/page/proposal/VoteTypeCheckbox.tsx
+++ b/dapp/src/components/page/proposal/VoteTypeCheckbox.tsx
@@ -23,7 +23,11 @@ const VoteTypeCheckbox: FC<Props> = ({
   const width = `${sizeMap[size]}px`,
     height = `${sizeMap[size]}px`;
   const renderIcon = () => {
-    if (voteType == currentVoteType || !currentVoteType) {
+    if (currentVoteType === null) {
+      return <img src="/icons/check-blank.svg" style={{ width, height }} />;
+    }
+
+    if (voteType == currentVoteType || currentVoteType === undefined) {
       if (voteType == VoteType.APPROVE) {
         return <img src="/icons/check-approve.svg" style={{ width, height }} />;
       }

--- a/dapp/src/components/page/proposal/VotingModal.tsx
+++ b/dapp/src/components/page/proposal/VotingModal.tsx
@@ -25,9 +25,7 @@ const VotingModal: React.FC<VotersModalProps> = ({
   setIsVoted,
   onClose,
 }) => {
-  const [selectedOption, setSelectedOption] = useState<VoteType | null>(
-    VoteType.APPROVE,
-  );
+  const [selectedOption, setSelectedOption] = useState<VoteType | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [step, setStep] = useState(1);
   const [voteError, setVoteError] = useState<string | null>(null);


### PR DESCRIPTION
Fixes issue where a vote option was pre-selected in the voting modal.

The state now initializes as null so no option is selected by default. The checkbox component was updated to explicitly handle null as an unselected state while preserving existing behavior.

This keeps the logic simple and avoids using any workaround values.

closes #105 