### PR TITLE
fix: highlight anonymous votes over max weight

### DIFF
--- a/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
+++ b/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
@@ -59,17 +59,28 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
                   </tr>
                 </thead>
                 <tbody>
-                  {decodedVotes.map((v, i) => (
-                    <tr key={i} className="odd:bg-white even:bg-zinc-50">
-                      <td className="p-1">
-                        <AddressDisplay address={v.address} />
-                      </td>
-                      <td className="p-1">{v.vote}</td>
-                      <td className="p-1">{v.weight}</td>
-                      <td className="p-1">{v.maxWeight}</td>
-                      <td className="p-1">{v.seed}</td>
-                    </tr>
-                  ))}
+                  {decodedVotes.map((v, i) => {
+                    const maxWeight = Number(v.maxWeight);
+                    const exceedsMaxWeight =
+                      Number.isFinite(maxWeight) && v.weight > maxWeight;
+
+                    return (
+                      <tr
+                        key={i}
+                        className={`odd:bg-white even:bg-zinc-50 ${
+                          exceedsMaxWeight ? "!bg-yellow-100" : ""
+                        }`}
+                      >
+                        <td className="p-1">
+                          <AddressDisplay address={v.address} />
+                        </td>
+                        <td className="p-1">{v.vote}</td>
+                        <td className="p-1">{v.weight}</td>
+                        <td className="p-1">{v.maxWeight}</td>
+                        <td className="p-1">{v.seed}</td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
Highlights decoded anonymous vote rows when the decoded vote weight is greater than the voter’s max allowed weight.

This is a visual-only indicator to help identify inconsistent anonymous vote data during review. It does not block the flow, change validation, or affect vote execution.

Closes #108
