### PR TITLE
fix: replace HTML comments with MDX v3-compatible syntax

### DIFF
--- a/website/blog/2024-07-15-welcome.mdx
+++ b/website/blog/2024-07-15-welcome.mdx
@@ -9,7 +9,7 @@ This is the beginning for Tansu! We are happy to have received a Stellar Communi
 
 Bellow is the proposal we made for the SCF28. The full proposal can be found [here](https://dashboard.communityfund.stellar.org/scfawards/scf-28_43/activationawardreview/suggestion/1150).
 
-<!-- truncate -->
+{/* truncate */}
 
 ## Introduction
 

--- a/website/blog/2024-08-01-testnet.mdx
+++ b/website/blog/2024-08-01-testnet.mdx
@@ -7,7 +7,7 @@ tags: [soroban, scf]
 
 A quick update 😃 The project is progressing very well and the contract is on testnet!
 
-<!-- truncate -->
+{/* truncate */}
 
 ## Contract
 

--- a/website/blog/2024-09-15-v1.mdx
+++ b/website/blog/2024-09-15-v1.mdx
@@ -11,7 +11,7 @@ Tansu is not officially available on testnet and people can register their proje
 
 https://testnet.tansu.dev/
 
-<!-- truncate -->
+{/* truncate */}
 
 ![V1 dApp landing page](/assets/blog/v1_landing.png)
 

--- a/website/blog/2024-09-22-build_submission.mdx
+++ b/website/blog/2024-09-22-build_submission.mdx
@@ -7,7 +7,7 @@ tags: [scf]
 
 I am happy to let you know that I filled out our application for the SCF Build! I am sharing here what we have planned. I really hope we get the opportunity to build all that for the community 😻 Don't forget to vote 🤗
 
-<!-- truncate -->
+{/* truncate */}
 
 After a successful POC phase. Tansu is starting to show our vision and can be played with on Testnet. We have an ambitious proposal for the Build award. Besides the road to mainnet and real adoption, we have two objectives:
 

--- a/website/blog/2024-09-25-donate.mdx
+++ b/website/blog/2024-09-25-donate.mdx
@@ -7,7 +7,7 @@ tags: [dapp]
 
 Tansu got a new button, and it's a `Support` one! Funding open source software has always been a point of contention. Adding this simple support mechanism is just a glimpse into what Tansu will offer to project maintainers automagically.
 
-<!-- truncate -->
+{/* truncate */}
 
 ![Support button modal in the dApp](/assets/blog/support_feature.png)
 

--- a/website/blog/2024-10-04-verified_contract.mdx
+++ b/website/blog/2024-10-04-verified_contract.mdx
@@ -7,7 +7,7 @@ tags: [soroban]
 
 Tansu's goal is to provide a way to validate projects with on-chain data. This can only work if Tansu's contract is actually what you think it is. This is why we are happy to share that we added support for [stellar.expert](https://stellar.expert/explorer/public)'s contract validation mechanism.
 
-<!-- truncate -->
+{/* truncate */}
 
 There are many aspects to consider when looking at securing the software supply-chain. Anything from the source code production to a user interaction is susceptible to vulnerabilities being introduced. [SLSA](https://slsa.dev), short for Supply-chain Levels for Software Artifacts, is a framework, set of standards, helping secure all aspects of a software's life cycle.
 

--- a/website/blog/2024-10-20-ipfs.mdx
+++ b/website/blog/2024-10-20-ipfs.mdx
@@ -9,7 +9,7 @@ After enabling contract validation, we continued our security journey are we are
 
 Diving into IPFS can be daunting. The documentation and information out there is at time very sparse or confusing for newcomers. Let me walk you through how we did that and hopefully help you cut some corners if you are new to IPFS as we are.
 
-<!-- truncate -->
+{/* truncate */}
 
 ### (Super short) Primer on IPFS
 

--- a/website/blog/2024-12-07-dao.mdx
+++ b/website/blog/2024-12-07-dao.mdx
@@ -9,7 +9,7 @@ Tansu is getting a Decentralized Autonomous Organization (DAO) system! Communiti
 
 All projects created on Tansu will get their very own DAO. Forget sending an email as a dead letter to a mailing list, with a DAO, there are clear rules, the process is transparent, more fair and there is an immutable record of every single decision.
 
-<!-- truncate -->
+{/* truncate */}
 
 ### Decentralized Autonomous Organization (DAO)
 

--- a/website/blog/2024-12-21-build_award.mdx
+++ b/website/blog/2024-12-21-build_award.mdx
@@ -11,4 +11,4 @@ You can read up the official announcement [here](https://medium.com/stellar-comm
 
 See the [post](2024-09-22-build_submission.mdx) I made for our submission for more details. We are more than on track for the MVP phase and even added some extra features such as IPFS support for the proposals.
 
-<!-- truncate -->
+{/* truncate */}

--- a/website/blog/2025-01-31-tranche_1.mdx
+++ b/website/blog/2025-01-31-tranche_1.mdx
@@ -9,7 +9,7 @@ Tansu validated the deliverable for the first tranche of its Stellar Community F
 
 ![Award illustration](/assets/blog/tansu_awarded.png)
 
-<!-- truncate -->
+{/* truncate */}
 
 As defined in our proposal we set ourselves to complete the following 3 milestones during that tranche. We have successfully delivered them.
 

--- a/website/blog/2025-06-17-anonymous_voting.mdx
+++ b/website/blog/2025-06-17-anonymous_voting.mdx
@@ -8,7 +8,7 @@ tags: ["dao", "soroban"]
 
 Tansu now supports **anonymous voting** for proposals, allowing members to cast votes without revealing their choices on-chain. This post details the cryptographic protocol, smart contract interface, and how to interact with the feature manually.
 
-<!-- truncate -->
+{/* truncate */}
 
 ## (Super short) Primer on zero-knowledge
 

--- a/website/blog/2025-10-26-mainnet.mdx
+++ b/website/blog/2025-10-26-mainnet.mdx
@@ -8,7 +8,7 @@ tags: [soroban, dapp]
 
 Tansu is live on mainnet! 🚀
 
-<!-- truncate -->
+{/* truncate */}
 
 We're excited to announce that Tansu is now officially deployed on Stellar's mainnet!
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -37,9 +37,6 @@ const config: Config = {
 
   markdown: {
     mermaid: true,
-    mdx1Compat: {
-      comments: true,
-    },
   },
 
   presets: [


### PR DESCRIPTION
fixed #79 

Shell git commit --amend -m "fix: replace HTML comments with MDX v3-compatible syntax
  
  MDX v3 (used in Docusaurus v3) no longer supports HTML-style comments
  (<!-- -->). All occurrences of <!-- truncate --> in blog posts have been
  replaced with the MDX-compatible equivalent ({/* truncate */}).
  
  Affected files (12):
  - website/blog/2024-07-15-welcome.mdx
  - website/blog/2024-08-01-testnet.mdx
  - website/blog/2024-09-15-v1.mdx
  - website/blog/2024-09-22-build_submission.mdx
  - website/blog/2024-09-25-donate.mdx
  - website/blog/2024-10-04-verified_contract.mdx
  - website/blog/2024-10-20-ipfs.mdx
  - website/blog/2024-12-07-dao.mdx
  - website/blog/2024-12-21-build_award.mdx
  - website/blog/2025-01-31-tranche_1.mdx
  - website/blog/2025-06-17-anonymous_voting.mdx
  - website/blog/2025-10-26-mainnet.mdx
  
  Ref: https://github.com/facebook/docusaurus/discussions/11152"
    ╰ working_dir=/workspaces/tansu
● Shell git push --force-with-lease
    ╰ working_dir=/workspaces/tansu
    To https://github.com/Mrchinedum/tansu
     + bdc57f7...776f1fe fix/mdx-v3-comments -> fix/mdx-v3-comments (forced update)

  Done. Amended and force-pushed with the detailed commit message