### PR TITLE
ci: upload SBOMs with Filebase

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -72,12 +72,9 @@ jobs:
           )"
           printf '%s\n' "${FILEBASE_RESPONSE}"
 
-          cid="$(printf '%s\n' "${FILEBASE_RESPONSE}" | jq -r 'select(.Hash != null) | select((.Name // "") == "") | .Hash' | tail -n 1)"
-          if [ -z "${cid}" ] || [ "${cid}" = "null" ]; then
-            cid="$(printf '%s\n' "${FILEBASE_RESPONSE}" | jq -r '.Hash // .Cid // empty' | tail -n 1)"
-          fi
+          cid="$(printf '%s\n' "${FILEBASE_RESPONSE}" | jq -r '.Hash // .Cid // empty' | tail -n 1)"
 
-          if [ -z "${cid}" ] || [ "${cid}" = "null" ]; then
+          if [ -z "${cid}" ]; then
             echo "Unable to determine Filebase directory CID from upload response" >&2
             exit 1
           fi

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -62,24 +62,19 @@ jobs:
         env:
           FILEBASE_TOKEN: ${{ secrets.FILEBASE_TOKEN }}
         run: |
-          if [ -z "${FILEBASE_TOKEN}" ]; then
-            echo "FILEBASE_TOKEN secret is required to upload SBOMs to Filebase" >&2
-            exit 1
-          fi
+          FILEBASE_RESPONSE="$(
+            curl --silent --show-error --fail \
+              -X POST \
+              -H "Authorization: Bearer ${FILEBASE_TOKEN}" \
+              "https://rpc.filebase.io/api/v0/add?wrap-with-directory=true" \
+              -F "file=@sbom-release/sbom.spdx.json;filename=sbom.spdx.json;type=application/json" \
+              -F "file=@sbom-release/sbom.cyclonedx.json;filename=sbom.cyclonedx.json;type=application/json"
+          )"
+          printf '%s\n' "${FILEBASE_RESPONSE}"
 
-          response_file="$(mktemp)"
-          curl --silent --show-error --fail-with-body \
-            -X POST \
-            -H "Authorization: Bearer ${FILEBASE_TOKEN}" \
-            "https://rpc.filebase.io/api/v0/add?wrap-with-directory=true&cid-version=1" \
-            -F "file=@sbom-release/sbom.spdx.json;filename=sbom.spdx.json" \
-            -F "file=@sbom-release/sbom.cyclonedx.json;filename=sbom.cyclonedx.json" \
-            --output "${response_file}"
-          cat "${response_file}"
-
-          cid="$(jq -r 'select(.Hash != null) | select((.Name // "") == "") | .Hash' "${response_file}" | tail -n 1)"
+          cid="$(printf '%s\n' "${FILEBASE_RESPONSE}" | jq -r 'select(.Hash != null) | select((.Name // "") == "") | .Hash' | tail -n 1)"
           if [ -z "${cid}" ] || [ "${cid}" = "null" ]; then
-            cid="$(jq -r 'select(.Hash != null) | .Hash' "${response_file}" | tail -n 1)"
+            cid="$(printf '%s\n' "${FILEBASE_RESPONSE}" | jq -r '.Hash // .Cid // empty' | tail -n 1)"
           fi
 
           if [ -z "${cid}" ] || [ "${cid}" = "null" ]; then

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          apk add --no-cache curl wget git
+          apk add --no-cache curl wget git jq
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -57,22 +57,49 @@ jobs:
           cp sbom.spdx.json sbom-release/
           cp sbom.cyclonedx.json sbom-release/
 
-      - name: Upload SBOMs to IPFS
-        uses: storacha/add-to-web3@892505d8e70c79336721485e5500155c17a728e0
-        id: storacha
-        with:
-          path_to_add: "sbom-release"
-          secret_key: ${{ secrets.STORACHA_PRINCIPAL }}
-          proof: ${{ secrets.STORACHA_PROOF }}
+      - name: Upload SBOMs to Filebase
+        id: filebase
+        env:
+          FILEBASE_TOKEN: ${{ secrets.FILEBASE_TOKEN }}
+        run: |
+          if [ -z "${FILEBASE_TOKEN}" ]; then
+            echo "FILEBASE_TOKEN secret is required to upload SBOMs to Filebase" >&2
+            exit 1
+          fi
+
+          response_file="$(mktemp)"
+          curl --silent --show-error --fail-with-body \
+            -X POST \
+            -H "Authorization: Bearer ${FILEBASE_TOKEN}" \
+            "https://rpc.filebase.io/api/v0/add?wrap-with-directory=true&cid-version=1" \
+            -F "file=@sbom-release/sbom.spdx.json;filename=sbom.spdx.json" \
+            -F "file=@sbom-release/sbom.cyclonedx.json;filename=sbom.cyclonedx.json" \
+            --output "${response_file}"
+          cat "${response_file}"
+
+          cid="$(jq -r 'select(.Hash != null) | select((.Name // "") == "") | .Hash' "${response_file}" | tail -n 1)"
+          if [ -z "${cid}" ] || [ "${cid}" = "null" ]; then
+            cid="$(jq -r 'select(.Hash != null) | .Hash' "${response_file}" | tail -n 1)"
+          fi
+
+          if [ -z "${cid}" ] || [ "${cid}" = "null" ]; then
+            echo "Unable to determine Filebase directory CID from upload response" >&2
+            exit 1
+          fi
+
+          {
+            echo "cid=${cid}"
+            echo "url=https://ipfs.filebase.io/ipfs/${cid}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Job summary
         run: |
-          echo "### SBOMs uploaded to IPFS! :rocket:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### SBOMs uploaded to IPFS! :rocket:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Release: ${GITHUB_REF_NAME}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- CID: ${STEPS_STORACHA_OUTPUTS_CID}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- URL: ${STEPS_STORACHA_OUTPUTS_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- CID: ${STEPS_FILEBASE_OUTPUTS_CID}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- URL: ${STEPS_FILEBASE_OUTPUTS_URL}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Formats: SPDX JSON, CycloneDX JSON" >> "$GITHUB_STEP_SUMMARY"
         env:
-          STEPS_STORACHA_OUTPUTS_CID: ${{ steps.storacha.outputs.cid }}
-          STEPS_STORACHA_OUTPUTS_URL: ${{ steps.storacha.outputs.url }}
+          STEPS_FILEBASE_OUTPUTS_CID: ${{ steps.filebase.outputs.cid }}
+          STEPS_FILEBASE_OUTPUTS_URL: ${{ steps.filebase.outputs.url }}


### PR DESCRIPTION
## Summary
- replace the Storacha SBOM upload action with a Filebase IPFS RPC upload
- switch the SBOM summary output to the Filebase CID and gateway URL
- keep the generated SPDX and CycloneDX artifact upload unchanged

Closes #129

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/sbom.yml'); puts 'yaml ok'"
- git diff --check
- checked that the SBOM workflow no longer references Storacha