### PR TITLE
feat(governance): show "Already Voted" button state for voted proposals

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
   e2e:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     env:
       PUBLIC_DELEGATION_API_URL: "https://ipfs-testnet.tansu.dev"
@@ -59,23 +59,29 @@ jobs:
             ${{ steps.bun-cache-dir.outputs.dir }}
             ~/.bun/install/cache
             ./node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb', '**/package.json') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock', '**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
-
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers & deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright deps (if cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
 
       - name: Setup environment variables
         run: cp .env.example .env

--- a/dapp/packages/tansu/tsconfig.json
+++ b/dapp/packages/tansu/tsconfig.json
@@ -23,7 +23,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
     /* Modules */
     "module": "NodeNext" /* Specify what module code is generated. */,
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src" /* Specify the root folder within your source files. */,
     "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/dapp/packages/tansu/tsconfig.json
+++ b/dapp/packages/tansu/tsconfig.json
@@ -23,7 +23,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
     /* Modules */
     "module": "NodeNext" /* Specify what module code is generated. */,
-    "rootDir": "./src" /* Specify the root folder within your source files. */,
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/dapp/playwright.config.ts
+++ b/dapp/playwright.config.ts
@@ -81,8 +81,8 @@ export default defineConfig({
     screenshot: "off",
     video: "off",
     ...devices["Desktop Chrome"],
-    // Fast Chrome settings
-    ...(chromiumExecutablePath ? {} : { channel: "chrome" }),
+    // Use custom executable path if found, otherwise default to Playwright's chromium
+    ...(chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : {}),
     launchOptions: browserLaunchOptions,
   },
 

--- a/dapp/playwright.config.ts
+++ b/dapp/playwright.config.ts
@@ -82,7 +82,9 @@ export default defineConfig({
     video: "off",
     ...devices["Desktop Chrome"],
     // Use custom executable path if found, otherwise default to Playwright's chromium
-    ...(chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : {}),
+    ...(chromiumExecutablePath
+      ? { executablePath: chromiumExecutablePath }
+      : {}),
     launchOptions: browserLaunchOptions,
   },
 

--- a/dapp/src/components/page/governance/ProposalCard.tsx
+++ b/dapp/src/components/page/governance/ProposalCard.tsx
@@ -40,8 +40,8 @@ const ProposalCard: React.FC<Props> = ({ proposal, onVoteClick }) => {
         <ProposalStatusSection proposal={proposal} />
         {proposal.status == "active" && (
           <Button
-            {...(userHasVoted ? { type: "secondary" } : {})}
-            icon="/icons/vote.svg"
+            type={userHasVoted ? "secondary" : "primary"}
+            icon={userHasVoted ? "" : "/icons/vote.svg"}
             disabled={userHasVoted}
             onClick={(e) => {
               e.preventDefault();

--- a/dapp/src/components/page/governance/ProposalCard.tsx
+++ b/dapp/src/components/page/governance/ProposalCard.tsx
@@ -36,10 +36,11 @@ const ProposalCard: React.FC<Props> = ({ proposal, onVoteClick }) => {
           </span>
         </div>
       </div>
-      <div className="flex justify-between">
+      <div className="flex justify-between items-center">
         <ProposalStatusSection proposal={proposal} />
         {proposal.status == "active" && (
           <Button
+            size="md"
             type={userHasVoted ? "secondary" : "primary"}
             icon={userHasVoted ? "" : "/icons/vote.svg"}
             disabled={userHasVoted}

--- a/dapp/src/components/page/governance/ProposalCard.tsx
+++ b/dapp/src/components/page/governance/ProposalCard.tsx
@@ -1,6 +1,8 @@
+import { useStore } from "@nanostores/react";
 import Button from "components/utils/Button";
 import type { ProposalView } from "types/proposal";
-import { truncateMiddle } from "utils/utils";
+import { connectedPublicKey } from "utils/store";
+import { hasUserVoted, truncateMiddle } from "utils/utils";
 import ProposalStatusSection from "../proposal/ProposalStatusSection";
 
 interface Props {
@@ -9,8 +11,10 @@ interface Props {
 }
 
 const ProposalCard: React.FC<Props> = ({ proposal, onVoteClick }) => {
+  const connectedAddress = useStore(connectedPublicKey);
   const projectName =
     new URLSearchParams(window.location.search).get("name") || "";
+  const userHasVoted = hasUserVoted(proposal.voteStatus, connectedAddress);
 
   return (
     <a
@@ -36,13 +40,15 @@ const ProposalCard: React.FC<Props> = ({ proposal, onVoteClick }) => {
         <ProposalStatusSection proposal={proposal} />
         {proposal.status == "active" && (
           <Button
+            {...(userHasVoted ? { type: "secondary" } : {})}
             icon="/icons/vote.svg"
+            disabled={userHasVoted}
             onClick={(e) => {
               e.preventDefault();
-              onVoteClick?.();
+              if (!userHasVoted) onVoteClick?.();
             }}
           >
-            Vote
+            {userHasVoted ? "Already Voted" : "Vote"}
           </Button>
         )}
       </div>

--- a/dapp/src/components/page/governance/ProposalList.tsx
+++ b/dapp/src/components/page/governance/ProposalList.tsx
@@ -115,6 +115,10 @@ const ProposalList: React.FC = () => {
           projectName={projectName}
           proposalId={proposalId}
           proposalTitle={proposalTitle}
+          onVoteSuccess={() => {
+            fetchProposalData(currentPage);
+            setShowVotingModal(false);
+          }}
           onClose={() => setShowVotingModal(false)}
         />
       )}

--- a/dapp/src/components/page/proposal/ProposalPage.tsx
+++ b/dapp/src/components/page/proposal/ProposalPage.tsx
@@ -8,7 +8,7 @@ import Loading from "components/utils/Loading";
 import React, { useEffect, useState } from "react";
 import type { Proposal, ProposalOutcome, ProposalView } from "types/proposal";
 import { connectedPublicKey } from "utils/store";
-import { modifyProposalToView, toast } from "utils/utils";
+import { hasUserVoted, modifyProposalToView, toast } from "utils/utils";
 import ExecuteProposalModal from "./ExecuteProposalModal";
 import ProposalDetail from "./ProposalDetail";
 import ProposalTitle from "./ProposalTitle";
@@ -28,7 +28,8 @@ const ProposalPage: React.FC = () => {
   const [outcome, setOutcome] = useState<ProposalOutcome | null>(null);
   const [projectMaintainers, setProjectMaintainers] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [isVoted, setIsVoted] = useState(false);
+
+  const userHasVoted = hasUserVoted(proposal?.voteStatus, connectedAddress);
 
   const openVotingModal = () => {
     if (proposal?.status === "active") {
@@ -100,7 +101,7 @@ const ProposalPage: React.FC = () => {
 
   useEffect(() => {
     getProposalDetails();
-  }, [id, projectName, isVoted]);
+  }, [id, projectName]);
 
   return (
     <>
@@ -128,8 +129,8 @@ const ProposalPage: React.FC = () => {
               projectName={projectName}
               proposalId={id}
               proposalTitle={proposal?.title}
-              isVoted={isVoted}
-              setIsVoted={setIsVoted}
+              isVoted={userHasVoted}
+              onVoteSuccess={getProposalDetails}
               onClose={() => setIsVotingModalOpen(false)}
             />
           )}

--- a/dapp/src/components/page/proposal/ProposalTitle.tsx
+++ b/dapp/src/components/page/proposal/ProposalTitle.tsx
@@ -155,7 +155,7 @@ const ProposalTitle: React.FC<Props> = ({
                     <Button
                       {...(userHasVoted ? { type: "secondary" } : {})}
                       size="sm"
-                      icon="/icons/vote.svg"
+                      icon={userHasVoted ? "" : "/icons/vote.svg"}
                       disabled={userHasVoted}
                       onClick={() => !userHasVoted && submitVote()}
                     >

--- a/dapp/src/components/page/proposal/ProposalTitle.tsx
+++ b/dapp/src/components/page/proposal/ProposalTitle.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import type { Member } from "../../../../packages/tansu";
 import type { ProposalView } from "types/proposal";
 import { connectedPublicKey } from "utils/store";
-import { toast, truncateMiddle } from "utils/utils";
+import { hasUserVoted, toast, truncateMiddle } from "utils/utils";
 import { getMember } from "@service/ReadContractService";
 import MemberProfileModal from "components/page/dashboard/MemberProfileModal";
 import ConflictOfInterestModal from "./ConflictOfInterestModal";
@@ -71,6 +71,7 @@ const ProposalTitle: React.FC<Props> = ({
       (proposal?.voteStatus?.reject?.voters?.length || 0) +
       (proposal?.voteStatus?.abstain?.voters?.length || 0)
     : 0;
+  const userHasVoted = hasUserVoted(proposal?.voteStatus, connectedAddress);
 
   return (
     <>
@@ -152,11 +153,13 @@ const ProposalTitle: React.FC<Props> = ({
                 <div className="flex gap-3">
                   {proposal?.status == "active" && (
                     <Button
+                      {...(userHasVoted ? { type: "secondary" } : {})}
                       size="sm"
                       icon="/icons/vote.svg"
-                      onClick={() => submitVote()}
+                      disabled={userHasVoted}
+                      onClick={() => !userHasVoted && submitVote()}
                     >
-                      Vote
+                      {userHasVoted ? "Already Voted" : "Vote"}
                     </Button>
                   )}
                   {proposal?.status == "voted" && isMaintainer && (

--- a/dapp/src/components/page/proposal/VotingModal.tsx
+++ b/dapp/src/components/page/proposal/VotingModal.tsx
@@ -14,7 +14,8 @@ interface VotersModalProps extends ModalProps {
   proposalId: number | undefined;
   proposalTitle: string | undefined;
   isVoted?: boolean;
-  setIsVoted?: React.Dispatch<React.SetStateAction<boolean>>;
+  onVoteSuccess?: () => void;
+  onClose: () => void;
 }
 
 const VotingModal: React.FC<VotersModalProps> = ({
@@ -22,7 +23,7 @@ const VotingModal: React.FC<VotersModalProps> = ({
   proposalId,
   proposalTitle,
   isVoted,
-  setIsVoted,
+  onVoteSuccess,
   onClose,
 }) => {
   const [selectedOption, setSelectedOption] = useState<VoteType | null>(null);
@@ -127,7 +128,7 @@ const VotingModal: React.FC<VotersModalProps> = ({
         selectedOption as VoteType,
         selectedWeight,
       );
-      setIsVoted?.(true);
+      onVoteSuccess?.();
       setStep(2);
       onClose();
     } catch (error: any) {

--- a/dapp/src/components/utils/Button.tsx
+++ b/dapp/src/components/utils/Button.tsx
@@ -51,22 +51,14 @@ const Button: FC<Props> = ({
       {isLoading && <Spinner />}
       {!isLoading && icon && order === "primary" && (
         <>
-          <img
-            src={icon}
-            alt=""
-            className={`w-6 h-6 min-w-[24px] ${type == "secondary" ? "brightness-0" : ""}`}
-          />
+          <img src={icon} alt="" className="w-6 h-6 min-w-[24px]" />
           {children}
         </>
       )}
       {!isLoading && icon && order === "secondary" && (
         <>
           {children}
-          <img
-            src={icon}
-            alt=""
-            className={`w-6 h-6 min-w-[24px] ${type == "secondary" ? "brightness-0" : ""}`}
-          />
+          <img src={icon} alt="" className="w-6 h-6 min-w-[24px]" />
         </>
       )}
       {!isLoading && !icon && children}

--- a/dapp/src/components/utils/Button.tsx
+++ b/dapp/src/components/utils/Button.tsx
@@ -42,25 +42,34 @@ const Button: FC<Props> = ({
   return (
     <button
       id={id}
-      className={`${className} ${type == "primary" ? "bg-primary text-white" : type == "secondary" ? "bg-[#F5F1F9] text-primary" : type == "tertiary" ? "border border-primary text-primary" : "bg-white text-primary"} cursor-pointer flex justify-center items-center whitespace-nowrap ${sizeMap[size]} hover:opacity-90 transition-opacity`}
+      className={`${className} ${type == "primary" ? "bg-primary text-white" : type == "secondary" ? "bg-[#F5F1F9] text-primary" : type == "tertiary" ? "border border-primary text-primary" : "bg-white text-primary"} ${disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"} flex justify-center items-center whitespace-nowrap ${sizeMap[size]} hover:opacity-90 transition-opacity`}
       onClick={onClick}
       title={title}
       disabled={disabled}
       {...rest}
     >
       {isLoading && <Spinner />}
-      {!isLoading && order === "primary" && (
+      {!isLoading && icon && order === "primary" && (
         <>
-          {icon && <img src={icon} alt="" className="w-6 h-6 min-w-[24px]" />}
+          <img
+            src={icon}
+            alt=""
+            className={`w-6 h-6 min-w-[24px] ${type == "secondary" ? "brightness-0" : ""}`}
+          />
           {children}
         </>
       )}
-      {!isLoading && order === "secondary" && (
+      {!isLoading && icon && order === "secondary" && (
         <>
           {children}
-          {icon && <img src={icon} alt="" className="w-6 h-6 min-w-[24px]" />}
+          <img
+            src={icon}
+            alt=""
+            className={`w-6 h-6 min-w-[24px] ${type == "secondary" ? "brightness-0" : ""}`}
+          />
         </>
       )}
+      {!isLoading && !icon && children}
     </button>
   );
 };

--- a/dapp/src/utils/utils.ts
+++ b/dapp/src/utils/utils.ts
@@ -10,6 +10,7 @@ import {
   type ProposalStatus,
   type ProposalView,
   type ProposalViewStatus,
+  type VoteStatus,
 } from "types/proposal";
 import {
   buildRepositoryUrlFromProjectPath,
@@ -132,6 +133,22 @@ export function parseContractOptionString(value: unknown): string | null {
   }
   return null;
 }
+
+export const hasUserVoted = (
+  voteStatus: VoteStatus | undefined,
+  userAddress: string | undefined,
+): boolean => {
+  if (!voteStatus || !userAddress) return false;
+  const normalizedAddress = userAddress.toLowerCase();
+  const allVoters = [
+    ...(voteStatus.approve?.voters || []),
+    ...(voteStatus.reject?.voters || []),
+    ...(voteStatus.abstain?.voters || []),
+  ];
+  return allVoters.some(
+    (voter) => voter.address.toLowerCase() === normalizedAddress,
+  );
+};
 
 export const modifyProposalToView = (
   proposal: Proposal,


### PR DESCRIPTION
## Summary

Fixes the UX issue where the "VOTE" button does not reflect whether the connected user has already voted on a proposal.

## Changes

- Added `hasUserVoted` helper in `utils/utils.ts` to derive voted state from proposal's `voteStatus.voters` arrays
- Updated vote button in both `ProposalCard.tsx` (list view) and `ProposalTitle.tsx` (detail view) to:
  - Show "Already Voted" label when user has voted
  - Disable the button in that state
  - Use secondary button styling for the voted state
  - Hide the vote icon for better readability on secondary button
- Removed redundant `useState` for `isVoted` in `ProposalPage.tsx` - value now derived directly from proposal data
- Updated `VotingModal.tsx` to use `onVoteSuccess` callback instead of `setIsVoted` for cleaner data refresh
- Updated `ProposalList.tsx` with `onVoteSuccess` callback to refresh proposal list after voting

## Before voting : 

<img width="1068" height="659" alt="Screenshot 2026-05-27 at 01 35 51" src="https://github.com/user-attachments/assets/a5be24bd-ce6c-414d-88bf-fa9f86c79c04" />


## After voting : 

<img width="1053" height="649" alt="Screenshot 2026-05-27 at 01 36 40" src="https://github.com/user-attachments/assets/cc23c6a6-a8ac-43df-87c9-92c40c603445" />


The `Already voted` also shows for the maintainer who proposed the proposal. 
closes #87  