### PR TITLE
feat: show all outcome weights and seeds in anonymous voting tallies

### DIFF
--- a/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
+++ b/dapp/src/components/page/proposal/AnonymousTalliesDisplay.tsx
@@ -84,9 +84,9 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
                   <tr className="bg-zinc-100 text-left">
                     <th className="p-2">Address</th>
                     <th>Vote</th>
-                    <th>Weight</th>
+                    <th>Weights (A/R/Abs)</th>
                     <th>Max</th>
-                    <th>Seed</th>
+                    <th>Seeds (A/R/Abs)</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -95,20 +95,32 @@ const AnonymousTalliesDisplay: React.FC<Props> = ({
                     const exceedsMaxWeight =
                       Number.isFinite(maxWeight) && v.weight > maxWeight;
 
+                    // Check if multiple outcome weights are non-zero (problematic vote)
+                    const nonZeroWeightCount = v.outcomeWeights.filter(
+                      (w) => w > 0,
+                    ).length;
+                    const hasMultipleNonZeroWeights = nonZeroWeightCount > 1;
+
                     return (
                       <tr
                         key={i}
                         className={`odd:bg-white even:bg-zinc-50 ${
-                          exceedsMaxWeight ? "!bg-yellow-100" : ""
+                          exceedsMaxWeight || hasMultipleNonZeroWeights
+                            ? "!bg-yellow-100"
+                            : ""
                         }`}
                       >
                         <td className="p-1">
                           <AddressDisplay address={v.address} />
                         </td>
                         <td className="p-1">{v.vote}</td>
-                        <td className="p-1">{v.weight}</td>
+                        <td className="p-1 font-mono">
+                          {v.outcomeWeights.join("/")}
+                        </td>
                         <td className="p-1">{v.maxWeight}</td>
-                        <td className="p-1">{v.seed}</td>
+                        <td className="p-1 font-mono">
+                          {v.outcomeSeeds.join("/")}
+                        </td>
                       </tr>
                     );
                   })}

--- a/dapp/src/utils/anonymousVoting.ts
+++ b/dapp/src/utils/anonymousVoting.ts
@@ -56,6 +56,9 @@ export interface DecodedVote {
   seed: number;
   weight: number;
   maxWeight: number | string;
+  // All outcome weights and seeds (for detecting problematic votes)
+  outcomeWeights: [number, number, number]; // [approve, reject, abstain]
+  outcomeSeeds: [number, number, number]; // [approve, reject, abstain]
 }
 
 export interface AnonymousVotingData {
@@ -165,6 +168,10 @@ export async function computeAnonymousVotingData(
       }
     }
 
+    // Capture all outcome weights and seeds for this voter
+    const outcomeWeights: [number, number, number] = [0, 0, 0];
+    const outcomeSeeds: [number, number, number] = [0, 0, 0];
+
     // Process each choice
     for (let i = 0; i < 3; i++) {
       if (i >= encryptedVotes.length || i >= encryptedSeeds.length) continue;
@@ -188,6 +195,10 @@ export async function computeAnonymousVotingData(
               .pop()!,
           );
 
+      // Store all outcome weights and seeds
+      outcomeWeights[i] = vDec;
+      outcomeSeeds[i] = sDec;
+
       if (vDec > 0) voteChoiceIdx = i;
       if (vDec > 0) selectedSeedRaw = sDec; // capture per-voter unweighted seed for display
 
@@ -210,6 +221,8 @@ export async function computeAnonymousVotingData(
       seed: selectedSeedRaw,
       weight,
       maxWeight,
+      outcomeWeights,
+      outcomeSeeds,
     });
   }
 

--- a/dapp/src/utils/anonymousVotingCsv.ts
+++ b/dapp/src/utils/anonymousVotingCsv.ts
@@ -1,6 +1,12 @@
 import type { DecodedVote } from "./anonymousVoting";
 
-const CSV_HEADERS = ["Address", "Vote", "Weight", "Max Weight", "Seed"];
+const CSV_HEADERS = [
+  "Address",
+  "Vote",
+  "Weight (A/R/Abs)",
+  "Max Weight",
+  "Seed (A/R/Abs)",
+];
 
 export function escapeCsvValue(value: unknown): string {
   const normalized = String(value ?? "");
@@ -13,7 +19,13 @@ export function escapeCsvValue(value: unknown): string {
 
 export function buildDecodedVotesCsv(decodedVotes: DecodedVote[]): string {
   const rows = decodedVotes.map((vote) =>
-    [vote.address, vote.vote, vote.weight, vote.maxWeight, vote.seed]
+    [
+      vote.address,
+      vote.vote,
+      vote.outcomeWeights.join("/"),
+      vote.maxWeight,
+      vote.outcomeSeeds.join("/"),
+    ]
       .map(escapeCsvValue)
       .join(","),
   );


### PR DESCRIPTION
- Add outcomeWeights and outcomeSeeds arrays to DecodedVote interface
- Capture all outcome weights and seeds for each voter in computeAnonymousVotingData
- Display all outcome weights and seeds in AnonymousTalliesDisplay table
- Highlight votes with multiple non-zero weights as problematic (yellow background)
- Update CSV export to include all outcome weights and seeds

Fixes #137