### PR TITLE
chore(radicle): update default seed host to iris.radicle.network

### DIFF
--- a/dapp/src/components/page/dashboard/CreateProjectModal.tsx
+++ b/dapp/src/components/page/dashboard/CreateProjectModal.tsx
@@ -535,7 +535,7 @@ ${maintainerGithubs.map((gh) => `[[PRINCIPALS]]\n${repositoryPrincipalField}="${
                       }}
                       description={
                         activeRepositoryProvider === "radicle"
-                          ? "Use a public Radicle RID such as rad:z3..., a rad:// reference, or a public seed URL."
+                          ? "Paste the full Radicle node URL when possible, e.g. https://radicle.network/nodes/iris.radicle.network/rad:z3gqc.... If only rad:... is provided, Tansu will use the default seed."
                           : `Supported formats are HTTPS or SSH URLs for ${repositoryProviderLabel}.`
                       }
                       error={githubRepoUrlError}
@@ -821,7 +821,7 @@ ${maintainerGithubs.map((gh) => `[[PRINCIPALS]]\n${repositoryPrincipalField}="${
                       }}
                       description={
                         activeRepositoryProvider === "radicle"
-                          ? "Use a public Radicle RID such as rad:z3..., a rad:// reference, or a public seed URL."
+                          ? "Paste the full Radicle node URL when possible, e.g. https://radicle.network/nodes/iris.radicle.network/rad:z3gqc.... If only rad:... is provided, Tansu will use the default seed."
                           : `Supported formats are HTTPS or SSH URLs for ${repositoryProviderLabel}.`
                       }
                       error={githubRepoUrlError}

--- a/dapp/src/components/page/project/UpdateConfigModal.tsx
+++ b/dapp/src/components/page/project/UpdateConfigModal.tsx
@@ -674,7 +674,7 @@ const UpdateConfigModal = () => {
                           }}
                           description={
                             activeRepositoryProvider === "radicle"
-                              ? "Use a public Radicle RID such as rad:z3..., a rad:// reference, or a public seed URL."
+                              ? "Paste the full Radicle node URL when possible, e.g. https://radicle.network/nodes/iris.radicle.network/rad:z3gqc.... If only rad:... is provided, Tansu will use the default seed."
                               : `Paste an HTTPS or SSH URL for ${repositoryProviderLabel}. The provider selector updates automatically when the URL is recognized.`
                           }
                           error={repoError || undefined}

--- a/dapp/src/service/RepositoryMetadataService.test.ts
+++ b/dapp/src/service/RepositoryMetadataService.test.ts
@@ -211,7 +211,7 @@ describe("RepositoryMetadataService", () => {
 
       if (
         url ===
-        `https://seed.radicle.xyz/api/v1/repos/${encodeURIComponent(RADICLE_RID)}/commits?page=1&per_page=1`
+        `https://iris.radicle.network/api/v1/repos/${encodeURIComponent(RADICLE_RID)}/commits?page=1&per_page=1`
       ) {
         return Promise.resolve(
           createJsonResponse([
@@ -228,7 +228,7 @@ describe("RepositoryMetadataService", () => {
 
       if (
         url ===
-        `https://seed.radicle.xyz/api/v1/repos/${encodeURIComponent(RADICLE_RID)}/commits/abc123`
+        `https://iris.radicle.network/api/v1/repos/${encodeURIComponent(RADICLE_RID)}/commits/abc123`
       ) {
         return Promise.resolve(
           createJsonResponse({
@@ -261,7 +261,7 @@ describe("RepositoryMetadataService", () => {
 
     await expect(getLatestCommitData(RADICLE_RID, "abc123")).resolves.toEqual({
       sha: "abc123",
-      html_url: `https://radicle.network/nodes/seed.radicle.xyz/${encodeURIComponent(RADICLE_RID)}`,
+      html_url: `https://radicle.network/nodes/iris.radicle.network/${encodeURIComponent(RADICLE_RID)}`,
       commit: {
         message: "Initial commit\n\nAdds project scaffolding",
         author: {

--- a/dapp/src/service/RepositoryMetadataService.ts
+++ b/dapp/src/service/RepositoryMetadataService.ts
@@ -80,7 +80,7 @@ const REQUEST_CACHE_TTL_MS = 30_000;
 const MAX_RETRY_ATTEMPTS = 2;
 const INITIAL_RETRY_DELAY_MS = 250;
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
-const RADICLE_PUBLIC_SEED_HOSTS = ["seed.radicle.xyz"] as const;
+const RADICLE_PUBLIC_SEED_HOSTS = ["iris.radicle.network"] as const;
 const responseCache = new Map<
   string,
   { expiresAt: number; response: Response }

--- a/dapp/src/utils/editLinkFunctions.test.ts
+++ b/dapp/src/utils/editLinkFunctions.test.ts
@@ -455,6 +455,9 @@ describe("Radicle repository helpers", () => {
     expect(getRepositoryCloneCommand("rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5")).toBe(
       "rad clone rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5",
     );
+    expect(buildRadicleBrowseUrl("rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5")).toBe(
+      "https://radicle.network/nodes/iris.radicle.network/rad%3Az3gqcJUoA1n9HaHKufZs5FCSGazv5",
+    );
     expect(
       getRepositorySeedHost(
         "https://seed.example/api/v1/repos/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5",

--- a/dapp/src/utils/editLinkFunctions.ts
+++ b/dapp/src/utils/editLinkFunctions.ts
@@ -21,7 +21,7 @@ const SUPPORTED_REPOSITORY_HOSTS = new Set([
   "gitea.com",
 ]);
 
-const RADICLE_PUBLIC_SEED_HOSTS = ["seed.radicle.xyz"] as const;
+const RADICLE_PUBLIC_SEED_HOSTS = ["iris.radicle.network"] as const;
 
 const RADICLE_KNOWN_SEED_HOSTS = new Set<string>(RADICLE_PUBLIC_SEED_HOSTS);
 
@@ -89,7 +89,8 @@ const REPOSITORY_PROVIDER_REPO_PLACEHOLDERS: Record<
   bitbucket: "https://bitbucket.org/workspace/repo",
   codeberg: "https://codeberg.org/owner/repo",
   gitea: "https://gitea.com/owner/repo",
-  radicle: "rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5",
+  radicle:
+    "https://radicle.network/nodes/iris.radicle.network/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5",
 };
 
 const REPOSITORY_PROVIDER_HANDLE_PLACEHOLDERS: Record<

--- a/dapp/src/utils/extractConfigData.test.ts
+++ b/dapp/src/utils/extractConfigData.test.ts
@@ -75,7 +75,7 @@ describe("extractConfigData", () => {
     const out = extractConfigData(
       {
         DOCUMENTATION: {
-          ORG_REPOSITORY_SEED: "seed.radicle.xyz",
+          ORG_REPOSITORY_SEED: "iris.radicle.network",
         },
         PRINCIPALS: [{ radicle: "cloudhead" }],
       },
@@ -83,7 +83,7 @@ describe("extractConfigData", () => {
     );
 
     expect(out.officials.githubLink).toBe(
-      "https://radicle.network/nodes/seed.radicle.xyz/rad%3Az3gqcJUoA1n9HaHKufZs5FCSGazv5",
+      "https://radicle.network/nodes/iris.radicle.network/rad%3Az3gqcJUoA1n9HaHKufZs5FCSGazv5",
     );
     expect(out.authorGithubNames).toEqual(["cloudhead"]);
   });


### PR DESCRIPTION
Update default seed host to iris.radicle.network
Improve descriptions to guide users on Radicle url handling