### PR TITLE
ci: add Netlify dapp deploy-preview workflow

### DIFF
--- a/.github/workflows/dapp-preview.yml
+++ b/.github/workflows/dapp-preview.yml
@@ -1,0 +1,102 @@
+# PR-triggered Netlify deploy preview for the dapp.
+#
+# Posts a preview URL on the PR that runs against the time-limits-removed Tansu
+# deployment on testnet (so reviewers can exercise the governance flow). The
+# preview environment (contract id, RPC, etc.) comes from the
+# `[context.deploy-preview.environment]` block in dapp/netlify.toml.
+#
+# Required repository secrets:
+#   NETLIFY_AUTH_TOKEN  — a Netlify personal access token
+#   NETLIFY_SITE_ID     — the target Netlify site's API ID
+#
+# Note: secrets are not exposed to PRs from forks, so this job only runs for
+# same-repo PRs. Open the demo PR within the fork that owns the Netlify site
+# (e.g. willemneal/tansu) to get a preview.
+#
+# (Repo convention pins actions by commit SHA; pin these tags to match.)
+name: dapp-preview
+
+on:
+  pull_request:
+    paths:
+      - "dapp/**"
+      - ".github/workflows/dapp-preview.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: dapp-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  netlify-preview:
+    name: Netlify deploy preview
+    runs-on: ubuntu-latest
+    # Secrets are unavailable to fork PRs — only run for same-repo PRs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    defaults:
+      run:
+        working-directory: ./dapp
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2"
+
+      - name: Install dapp dependencies
+        run: bun install
+
+      - name: Deploy Netlify preview
+        id: netlify
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          npx --yes netlify-cli@17 deploy \
+            --build \
+            --context deploy-preview \
+            --alias "pr-${{ github.event.number }}" \
+            --message "Preview for PR #${{ github.event.number }} (${{ github.sha }})" \
+            --json | tee deploy.json
+          echo "url=$(jq -r '.deploy_ssl_url // .deploy_url // .url' deploy.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = "${{ steps.netlify.outputs.url }}";
+            const marker = "<!-- tansu-dapp-preview -->";
+            const body = [
+              marker,
+              "### 🚀 Tansu dapp preview",
+              "",
+              "Runs against the **time-limits-removed Tansu** on testnet " +
+                "(`CDLQFXGG…HP3O` — SorobanDomain removed, per-project " +
+                "`min_voting_period`/`execute_delay`).",
+              "",
+              `**Preview URL:** ${url}`,
+            ].join("\n");
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+            }

--- a/dapp/netlify.toml
+++ b/dapp/netlify.toml
@@ -1,0 +1,24 @@
+# Netlify build + deploy-preview config.
+#
+# Deploy previews of this branch run against the time-limits-removed Tansu
+# deployment on testnet, so the governance flow (configurable voting period /
+# execute delay, no SorobanDomain) can be exercised from the preview URL.
+#
+# Production/staging keep using the env vars configured in the Netlify UI; only
+# the deploy-preview context is pinned here.
+
+[build]
+  command = "bun run build"
+  publish = "dist"
+
+[build.environment]
+  BUN_VERSION = "1.2"
+
+[context.deploy-preview.environment]
+  PUBLIC_SOROBAN_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+  PUBLIC_SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org:443"
+  PUBLIC_HORIZON_URL = "https://horizon-testnet.stellar.org"
+  # New Tansu (SorobanDomain removed, per-project min_voting_period/execute_delay)
+  PUBLIC_TANSU_CONTRACT_ID = "CDLQFXGGQHD3DJXMOO4T6O2IISWOEAL27GQZZS6MAQQBEAU2GYFTHP3O"
+  PUBLIC_TANSU_OWNER_ID = "GAUF7DU72VMB4IHGJLO3AHJWRKTFAJXWMB6LBXSJT5TLS2ARJFE6VCBZ"
+  PUBLIC_DELEGATION_API_URL = "https://ipfs-testnet.tansu.dev"


### PR DESCRIPTION
Standalone CI infra extracted from #163: a `pull_request`-triggered workflow that builds the dapp, deploys a Netlify preview (aliased `pr-<n>`), and comments the URL — plus the `dapp/netlify.toml` `[context.deploy-preview.environment]` block it reads (pinned to the time-limits-removed testnet Tansu so reviewers can exercise the governance flow).

Runs **only for same-repo PRs** — Netlify secrets (`NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`) aren't exposed to fork PRs, so the demo PR is opened in the fork that owns the Netlify site.

Intended as the base for #155 (per-project governance overrides), which stacks on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)