### PR TITLE
fix: resolve proposal creation with outcome contract function arguments

### DIFF
--- a/dapp/src/components/EnhancedContractFunctionSelector.tsx
+++ b/dapp/src/components/EnhancedContractFunctionSelector.tsx
@@ -53,7 +53,7 @@ export const EnhancedContractFunctionSelector: React.FC<
           initialSelectedFunction === selectedFunction &&
           initialArgs.length > 0;
         // Initialize args array with proper length and types
-        const newArgs = func.inputs.map((input, index) => {
+        const newArgs = func.inputs.map((_input, index) => {
           const existing = shouldUseInitialArgs
             ? initialArgs[index]
             : undefined;

--- a/dapp/src/components/EnhancedContractFunctionSelector.tsx
+++ b/dapp/src/components/EnhancedContractFunctionSelector.tsx
@@ -57,18 +57,7 @@ export const EnhancedContractFunctionSelector: React.FC<
           const existing = shouldUseInitialArgs
             ? initialArgs[index]
             : undefined;
-          if (existing !== undefined) {
-            if (
-              existing &&
-              typeof existing === "object" &&
-              "type" in existing &&
-              "value" in existing
-            ) {
-              return existing;
-            }
-            return { type: input.type, value: existing };
-          }
-          return { type: input.type, value: "" };
+          return existing !== undefined ? existing : "";
         });
         setArgs(newArgs);
       }
@@ -110,8 +99,7 @@ export const EnhancedContractFunctionSelector: React.FC<
 
   const handleArgChange = (index: number, value: any) => {
     const newArgs = [...args];
-    const inputType = selectedFunc?.inputs[index]?.type || "unknown";
-    newArgs[index] = { type: inputType, value };
+    newArgs[index] = value;
     setArgs(newArgs);
   };
 
@@ -288,13 +276,7 @@ interface ArgInputProps {
 }
 
 const ArgInput: React.FC<ArgInputProps> = ({ type, value, onChange }) => {
-  const normalizedValue =
-    value &&
-    typeof value === "object" &&
-    "value" in value &&
-    (value as { value: unknown }).value !== undefined
-      ? (value as { value: unknown }).value
-      : value;
+  const normalizedValue = value === undefined || value === null ? "" : value;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;

--- a/dapp/src/components/page/proposal/ProposalDetail.tsx
+++ b/dapp/src/components/page/proposal/ProposalDetail.tsx
@@ -358,86 +358,88 @@ export const OutcomeDetail: React.FC<{
 
   return (
     <div
-      className={`p-[30px] flex justify-between items-center bg-white rounded-md transition-all ${borderClass}`}
+      className={`p-[30px] flex flex-col gap-4 bg-white rounded-md transition-all ${borderClass}`}
     >
-      <div className="flex flex-col gap-3">
-        <div className="flex items-center gap-3">
-          <p
-            className={`text-xl font-medium ${
-              type === "approved"
-                ? "text-approved"
-                : type === "rejected"
-                  ? "text-rejected"
-                  : "text-cancelled"
-            }`}
-          >
-            {capitalizeFirstLetter(type || "")}
-          </p>
-          {isExecuted && (
-            <span
-              className={`px-3 py-1 text-xs font-bold uppercase border-[#FFB21E] bg-[#FFB21E] text-white border`}
-            >
-              Executed Outcome
-            </span>
-          )}
-        </div>
-        <p className="text-base font-semibold text-primary">
-          {detail.description}
+      <div className="flex items-center gap-3">
+        <p
+          className={`text-xl font-medium ${
+            type === "approved"
+              ? "text-approved"
+              : type === "rejected"
+                ? "text-rejected"
+                : "text-cancelled"
+          }`}
+        >
+          {capitalizeFirstLetter(type || "")}
         </p>
-        {detail.contract?.address?.trim() && (
-          <div className="space-y-2">
-            <div>
-              <p className="text-xs uppercase tracking-wide text-secondary">
-                Contract Address
-              </p>
-              <p className="font-mono text-sm text-primary break-all">
-                {detail.contract.address}
-              </p>
-            </div>
-            {detail.contract.execute_fn?.trim() ? (
-              <div>
-                <p className="text-xs uppercase tracking-wide text-secondary">
-                  Function Call
-                </p>
-                <p className="font-mono text-sm text-primary">
-                  {detail.contract.execute_fn}()
-                </p>
-                {detail.contract.args && detail.contract.args.length > 0 && (
-                  <div className="mt-2 space-y-1">
-                    <p className="text-xs uppercase tracking-wide text-secondary">
-                      Parameters
-                    </p>
-                    <div className="text-xs bg-gray-50 p-2 rounded border space-y-1">
-                      {detail.contract.args.map((arg, index) => (
-                        <div
-                          key={index}
-                          className="flex justify-between items-start gap-3"
-                        >
-                          <span className="font-medium text-primary">
-                            {getArgLabel(index)}
-                          </span>
-                          <span className="font-mono text-secondary break-all text-right">
-                            {formatContractValue(getDisplayArgValue(arg))}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            ) : (
-              <p className="text-sm text-secondary">(Function not selected)</p>
-            )}
-          </div>
-        )}
-        {detail.xdr && (
-          <div className="text-sm text-secondary">
-            <span className="inline-block w-2 h-2 bg-orange-500 rounded-full mr-2"></span>
-            XDR-based execution
-          </div>
+        {isExecuted && (
+          <span
+            className={`px-3 py-1 text-xs font-bold uppercase border-[#FFB21E] bg-[#FFB21E] text-white border`}
+          >
+            Executed Outcome
+          </span>
         )}
       </div>
-      {renderActionButton()}
+      <p className="text-base font-semibold text-primary">
+        {detail.description}
+      </p>
+      {detail.contract?.address?.trim() && (
+        <div className="space-y-2">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-secondary">
+              Contract Address
+            </p>
+            <p className="font-mono text-sm text-primary break-all">
+              {detail.contract.address}
+            </p>
+          </div>
+          {detail.contract.execute_fn?.trim() ? (
+            <div>
+              <p className="text-xs uppercase tracking-wide text-secondary">
+                Function Call
+              </p>
+              <p className="font-mono text-sm text-primary">
+                {detail.contract.execute_fn}()
+              </p>
+              {detail.contract.args && detail.contract.args.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  <p className="text-xs uppercase tracking-wide text-secondary">
+                    Parameters
+                  </p>
+                  <div className="text-xs bg-gray-50 p-2 rounded border space-y-1">
+                    {detail.contract.args.map((arg, index) => (
+                      <div
+                        key={index}
+                        className="flex justify-between items-start gap-3"
+                      >
+                        <span className="font-medium text-primary">
+                          {getArgLabel(index)}
+                        </span>
+                        <span className="font-mono text-secondary break-all text-right">
+                          {formatContractValue(getDisplayArgValue(arg))}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-secondary">(Function not selected)</p>
+          )}
+        </div>
+      )}
+      {detail.xdr && (
+        <div className="text-sm text-secondary">
+          <span className="inline-block w-2 h-2 bg-orange-500 rounded-full mr-2"></span>
+          XDR-based execution
+        </div>
+      )}
+      {renderActionButton() && (
+        <div className="flex justify-end">
+          {renderActionButton()}
+        </div>
+      )}
       {showModal && (
         <Modal onClose={() => setShowModal(false)}>
           {renderModalContent()}

--- a/dapp/src/components/page/proposal/ProposalDetail.tsx
+++ b/dapp/src/components/page/proposal/ProposalDetail.tsx
@@ -436,9 +436,7 @@ export const OutcomeDetail: React.FC<{
         </div>
       )}
       {renderActionButton() && (
-        <div className="flex justify-end">
-          {renderActionButton()}
-        </div>
+        <div className="flex justify-end">{renderActionButton()}</div>
       )}
       {showModal && (
         <Modal onClose={() => setShowModal(false)}>

--- a/dapp/src/service/FlowService.ts
+++ b/dapp/src/service/FlowService.ts
@@ -48,6 +48,46 @@ interface CreateProjectFlowParams {
   additionalFiles?: File[]; // Optional files like README.md for non-software projects
 }
 
+/** Patch the SDK's Spec to handle scSpecTypeVal for raw JS types.
+ *
+ * The bundled @stellar/stellar-sdk v15's Spec.nativeToScVal has no handling
+ * for raw JS values (string, number, boolean) when the target Soroban type
+ * is scSpecTypeVal (value 0).  ScVal instances don't work either because
+ * Astro/Vite bundling creates different class references, so instanceof
+ * checks always fail.
+ *
+ * We monkey-patch Spec.prototype.nativeToScVal to intercept scSpecTypeVal
+ * and convert JS primitives directly using the same bundled xdr module.
+ */
+import { xdr, Address } from "@stellar/stellar-sdk";
+import { Spec } from "@stellar/stellar-sdk/contract";
+
+const ORIG_NATIVE_TO_SC_VAL = Spec.prototype.nativeToScVal;
+Spec.prototype.nativeToScVal = function patchNativeToScVal(
+  val: any,
+  ty: any,
+): any {
+  // scSpecTypeVal switch() returns value 0.
+  if (ty.switch().value === 0) {
+    if (typeof val === "string") {
+      if (/^[GC][A-Z0-9]{55}$/.test(val)) {
+        return Address.fromString(val).toScVal();
+      }
+      return xdr.ScVal.scvString(val);
+    }
+    if (typeof val === "number" || typeof val === "bigint") {
+      const v = BigInt(val);
+      const lo = new xdr.Uint64(v & BigInt("0xFFFFFFFFFFFFFFFF"));
+      const hi = new xdr.Int64(v >> 64n);
+      return xdr.ScVal.scvI128(new xdr.Int128Parts({ hi, lo }));
+    }
+    if (typeof val === "boolean") {
+      return xdr.ScVal.scvBool(val);
+    }
+  }
+  return ORIG_NATIVE_TO_SC_VAL.call(this, val, ty);
+};
+
 /**
  * Create and sign a proposal transaction
  */
@@ -350,14 +390,13 @@ export async function createProjectFlow({
     signedTxXdr,
   });
 
-  // Step 4 – Verify CID matches
   if (uploadedCid !== cid) {
     throw new Error(
       `Critical CID mismatch: expected ${cid}, got ${uploadedCid}`,
     );
   }
 
-  // Step 5 – Send signed transaction
+  // Step 4 – Send signed transaction
   onProgress?.(9);
   await sendSignedTransactionLocal(signedTxXdr);
   invalidateQuery(queryKeys.projects.all);
@@ -406,7 +445,6 @@ export async function updateConfigFlow({
   githubRepoUrl,
   maintainers,
   onProgress,
-  additionalFiles,
 }: {
   tomlFile: File;
   githubRepoUrl: string;
@@ -415,7 +453,7 @@ export async function updateConfigFlow({
   additionalFiles?: File[];
 }): Promise<boolean> {
   // Step 1 – Calculate CID and pack CAR once
-  const filesToUpload = [tomlFile, ...(additionalFiles || [])];
+  const filesToUpload = [tomlFile];
   const { cid, carBlob } = await packFilesToCar(filesToUpload);
 
   // Step 2 – sign tx

--- a/dapp/src/service/FlowService.ts
+++ b/dapp/src/service/FlowService.ts
@@ -390,13 +390,14 @@ export async function createProjectFlow({
     signedTxXdr,
   });
 
+  // Step 4 – Verify CID matches
   if (uploadedCid !== cid) {
     throw new Error(
       `Critical CID mismatch: expected ${cid}, got ${uploadedCid}`,
     );
   }
 
-  // Step 4 – Send signed transaction
+  // Step 5 – Send signed transaction
   onProgress?.(9);
   await sendSignedTransactionLocal(signedTxXdr);
   invalidateQuery(queryKeys.projects.all);

--- a/dapp/src/service/FlowService.ts
+++ b/dapp/src/service/FlowService.ts
@@ -445,6 +445,7 @@ export async function updateConfigFlow({
   githubRepoUrl,
   maintainers,
   onProgress,
+  additionalFiles,
 }: {
   tomlFile: File;
   githubRepoUrl: string;
@@ -453,7 +454,7 @@ export async function updateConfigFlow({
   additionalFiles?: File[];
 }): Promise<boolean> {
   // Step 1 – Calculate CID and pack CAR once
-  const filesToUpload = [tomlFile];
+  const filesToUpload = [tomlFile, ...(additionalFiles || [])];
   const { cid, carBlob } = await packFilesToCar(filesToUpload);
 
   // Step 2 – sign tx


### PR DESCRIPTION
- Monkey-patch Spec.prototype.nativeToScVal to handle scSpecTypeVal for raw JS types (the bundled SDK v15 has no conversion for Val)
- Store outcome contract args as raw JS values instead of {type,value} wrapper objects in EnhancedContractFunctionSelector
- Fix proposal outcome card layout from 2-column to single column with action button at bottom right