### PR TITLE
fix: derive project key from raw name to match on-chain contract

### DIFF
--- a/dapp/src/service/OnChainActivityService.ts
+++ b/dapp/src/service/OnChainActivityService.ts
@@ -185,10 +185,10 @@ export async function fetchOnChainActions(
           case "register": {
             projectName = paramToString(args[1]); // name is arg1 (maintainer is arg0)
             if (projectName) {
-              // keccak key (derived) – used by some off-chain calls
-              const keyHex = normalizeHex(
-                keccak_256(projectName.toLowerCase()),
-              );
+              // keccak key (derived) – used by some off-chain calls.
+              // Hash the raw name to match the on-chain contract (case-sensitive),
+              // consistent with deriveProjectKey().
+              const keyHex = normalizeHex(keccak_256(projectName));
               PROJECT_CACHE.set(keyHex!, projectName);
               details.name = projectName;
 

--- a/dapp/src/service/StateService.ts
+++ b/dapp/src/service/StateService.ts
@@ -73,7 +73,7 @@ function setProjectId(project_name: string): void {
   projectState.project_name = project_name;
 
   projectState.project_id = Buffer.from(
-    keccak256.create().update(project_name.toLowerCase()).digest(),
+    keccak256.create().update(project_name).digest(),
   );
 
   if (typeof window !== "undefined") {

--- a/dapp/src/utils/projectKey.test.ts
+++ b/dapp/src/utils/projectKey.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { deriveProjectKey } from "./projectKey";
+
+// The on-chain contract derives the project key from keccak256 of the raw
+// (case-sensitive) project name. These expectations pin that behavior so the
+// frontend can never silently diverge from the contract again.
+describe("deriveProjectKey", () => {
+  it("hashes the raw name (case-sensitive), without lowercasing", () => {
+    // keccak256("MyProject") — the actual on-chain key for a mixed-case name.
+    expect(deriveProjectKey("MyProject").toString("hex")).toBe(
+      "5cf9c0e95198ffeb9ef583d208e91798eb10bbf881ec2526939f24f8049e7556",
+    );
+  });
+
+  it("derives a different key for the lowercase name (distinct projects)", () => {
+    expect(deriveProjectKey("myproject").toString("hex")).toBe(
+      "3908577ecee19ec0cddea99cf2a5d669521c838e1f57a619416f1e5311360ba4",
+    );
+  });
+
+  it("does not collapse case: 'MyProject' and 'myproject' yield different keys", () => {
+    expect(deriveProjectKey("MyProject").toString("hex")).not.toBe(
+      deriveProjectKey("myproject").toString("hex"),
+    );
+  });
+
+  it("leaves already-lowercase names unchanged (existing projects keep working)", () => {
+    expect(deriveProjectKey("tansu").toString("hex")).toBe(
+      deriveProjectKey("tansu".toLowerCase()).toString("hex"),
+    );
+  });
+
+  it("returns a 32-byte key", () => {
+    expect(deriveProjectKey("MyProject")).toHaveLength(32);
+  });
+});

--- a/dapp/src/utils/projectKey.ts
+++ b/dapp/src/utils/projectKey.ts
@@ -5,12 +5,11 @@ const { keccak256 } = pkg;
 
 /**
  * Derive the canonical project key from a project name.
- * Always lowercases the name before hashing to ensure consistent IDs across the app.
+ * Hashes the raw name (case-sensitive) to match the on-chain contract. Do NOT
+ * lowercase: the contract treats "MyProject" and "myproject" as distinct keys.
  */
 export function deriveProjectKey(projectName: string): Buffer {
-  return Buffer.from(
-    keccak256.create().update(projectName.toLowerCase()).digest(),
-  );
+  return Buffer.from(keccak256.create().update(projectName).digest());
 }
 
 const SUBPROJECT_KEY_BYTES = 32;


### PR DESCRIPTION
The contract derives the project key from keccak256 of the raw (case-sensitive) name, but the dapp lowercased the name before hashing. Projects registered with uppercase letters were stored under a key the dapp could never reproduce, making them unreachable in the UI.

Remove .toLowerCase() in all three key-derivation sites so the dapp derives the same key the contract stores:
- utils/projectKey.ts (deriveProjectKey)
- service/StateService.ts (setProjectId)
- service/OnChainActivityService.ts (register cache key)

Safe for existing lowercase projects (hashing an already-lowercase name is unchanged); recovers uppercase-named projects that were orphaned.