### PR TITLE
fix: preserve image draft on modal reopen and fully remove.

### DIFF
--- a/dapp/src/components/page/proposal/CreateProposalModal.tsx
+++ b/dapp/src/components/page/proposal/CreateProposalModal.tsx
@@ -7,7 +7,7 @@ import Label from "components/utils/Label";
 import FlowProgressModal from "components/utils/FlowProgressModal";
 import Step from "components/utils/Step";
 import Title from "components/utils/Title";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ProposalOutcome, OutcomeContract } from "types/proposal";
 import { formatDate } from "utils/formatTimeFunctions";
 import { connectedPublicKey } from "utils/store";
@@ -36,6 +36,20 @@ const CreateProposalModal = () => {
   // Local image handling for Markdown content
   const [imageFiles, setImageFiles] = useState<AttachedImage[]>([]);
   const [imageError, setImageError] = useState<string | null>(null);
+
+  // Keep a ref to the latest attached images so we can revoke their object URLs
+  // only when the component truly unmounts — NOT on modal close. Revoking on
+  // close (while the description markdown still references the blob: URLs) is
+  // what made images appear broken after reopening the modal (issue #177).
+  const imageFilesRef = useRef<AttachedImage[]>([]);
+  useEffect(() => {
+    imageFilesRef.current = imageFiles;
+  }, [imageFiles]);
+  useEffect(() => {
+    return () => {
+      imageFilesRef.current.forEach((img) => URL.revokeObjectURL(img.localUrl));
+    };
+  }, []);
 
   const [approveDescription, setApproveDescription] = useState("");
   const [rejectDescription, setRejectDescription] = useState("");
@@ -486,8 +500,9 @@ const CreateProposalModal = () => {
   };
 
   const handleCloseModal = () => {
-    imageFiles.forEach((img) => URL.revokeObjectURL(img.localUrl));
-    setImageFiles([]);
+    // Preserve the draft (description markdown + attached images + their live
+    // blob: URLs) so reopening the modal shows the images correctly. Object URLs
+    // are revoked on unmount instead (see effect above). Fixes issue #177.
     setShowModal(false);
     setStep(1);
   };

--- a/dapp/src/components/utils/MarkdownEditorWithImages.tsx
+++ b/dapp/src/components/utils/MarkdownEditorWithImages.tsx
@@ -139,7 +139,17 @@ const MarkdownEditorWithImages = ({
                       onImageFilesChange(
                         imageFiles.filter((_, i) => i !== idx),
                       );
-                      onChange(value.replaceAll(img.localUrl, ""));
+                      // Remove the whole markdown image node(s) for this URL, not
+                      // just the URL substring, so no empty `![]()` is left behind.
+                      const escaped = img.localUrl.replace(
+                        /[.*+?^${}()|[\]\\]/g,
+                        "\\$&",
+                      );
+                      const imageTag = new RegExp(
+                        `!\\[[^\\]]*\\]\\(${escaped}\\)\\n?`,
+                        "g",
+                      );
+                      onChange(value.replace(imageTag, ""));
                     }}
                   >
                     Remove


### PR DESCRIPTION
Fixes #177.

1. Broken image after reopening the Create Proposal modal: handleCloseModal revoked the attached images' blob: URLs and cleared imageFiles on close, while the description markdown (which persists) still referenced those now- dead URLs -> images rendered broken on reopen. 
Object URLs are now revoked only on component unmount; the draft is preserved across close/reopen.

2. Empty ![]() left after removing an image: the remove handler stripped only the URL substring. It now removes the whole markdown image node for that URL.




https://github.com/user-attachments/assets/ff09c4ec-9b1b-4e23-a753-4f17ca778986

