### PR TITLE
tansu commit 

### DIFF
--- a/dapp/src/components/page/dashboard/JoinCommunityModal.tsx
+++ b/dapp/src/components/page/dashboard/JoinCommunityModal.tsx
@@ -3,7 +3,7 @@ import Input from "components/utils/Input";
 import Button from "components/utils/Button";
 import FlowProgressModal from "components/utils/FlowProgressModal";
 import { loadedPublicKey, setConnection } from "@service/walletService";
-import { validateStellarAddress, validateUrl } from "utils/validations";
+import { validateUrl } from "utils/validations";
 import SimpleMarkdownEditor from "components/utils/SimpleMarkdownEditor";
 
 interface ProfileImageFile {
@@ -104,9 +104,9 @@ const JoinCommunityModal: FC<{
     name.trim() || social.trim() || description.trim() || profileImage;
 
   const validateAddressField = (): boolean => {
-    const err = validateStellarAddress(address);
-    setAddressError(err);
-    return err === null;
+    // Address is read-only and provided by wallet; skip validation
+    setAddressError(null);
+    return true;
   };
 
   const validateSocialField = (): boolean => {
@@ -175,7 +175,7 @@ const JoinCommunityModal: FC<{
       try {
         setIsLoading(true);
         setStep(6);
-        await doJoinFlow(address || publicKey);
+        await doJoinFlow(publicKey);
       } catch (err: any) {
         console.error("Join community error:", err);
         setError(err?.message || "Something went wrong");
@@ -199,6 +199,9 @@ const JoinCommunityModal: FC<{
           detail: { address: connectedAddress },
         }),
       );
+
+      // Reflect the actual connected address in the UI
+      setAddress(connectedAddress);
 
       try {
         setIsLoading(true);
@@ -248,12 +251,9 @@ const JoinCommunityModal: FC<{
 
           <Input
             label="Member Address *"
-            placeholder="Write the address as G..."
+            placeholder="Address will be filled upon connection"
             value={address}
-            onChange={(e) => {
-              setAddress(e.target.value);
-              setAddressError(null);
-            }}
+            disabled={true}
             error={addressError}
           />
 

--- a/dapp/tests/happy-flows.spec.ts
+++ b/dapp/tests/happy-flows.spec.ts
@@ -202,9 +202,7 @@ test.describe("Tansu dApp – Happy-path User Flows", () => {
       });
 
       // Fill minimal required fields
-      await page
-        .locator("input[placeholder='Write the address as G...']")
-        .fill("G".padEnd(56, "B"));
+      // (Address is now disabled and populated by the wallet upon connection)
       await page
         .locator("input[placeholder='https://twitter.com/yourhandle']")
         .fill("https://twitter.com/test");


### PR DESCRIPTION
Closes #179

  Summary & What Changed
  The "Join the Community" modal previously allowed users to type an arbitrary member address into the input field. Because the underlying contract 
  add_member  function requires the member to authorize their own registration ( member_address.require_auth() ), typing an address different from the
  connected wallet resulted in a cryptic transaction failure.
  This PR:

  • Disables the "Member Address" input field so it's strictly read-only.
  • Updates the  handleJoin  connected flow to enforce building the transaction strictly with the  publicKey .
  • Updates the disconnected flow to explicitly tie the  address  state to the returned  connectedAddress  immediately upon wallet connection.
  • Updates the  happy-flows.spec.ts  E2E test to align with the disabled input field behavior.
  Key Design Decisions

  • The easiest, most robust way to guarantee the source account matches the member address is tying the form directly to the wallet connection payload.
  Validating an arbitrary typed address was dropped because manual typing is fundamentally incompatible with the self-authorization required by the
  contract.

  Acceptance Criteria Checklist

  [✓] The UI clearly prevents entering an address the user cannot authorize (input is disabled).
  [✓] The connected vs. disconnected paths use the exact same logic (bound to the connected wallet).
  [✓] Typechecks and lint pass locally.

  Test & Coverage Output

  • E2E playwright tests run and pass cleanly ( 33 passed (1.9m) ).
  • Local typecheck ( astro check ) passes cleanly ( 0 errors ).
  • Note: No component-level unit test coverage metrics exist in this repo for  JoinCommunityModal.tsx , but e2e suites explicitly verify the visual
  presence and modal flow.

  Security Note
  The address payload sent to the join flow is now securely derived straight from the wallet payload instead of trusting generic client-side text input.

  Follow-Ups

  • A broader review of other forms using the generic  <Input>  component might be warranted to ensure there are no other instances where user input
  incorrectly drives authorization payloads.